### PR TITLE
fix: allow blob overwrite for skill package uploads

### DIFF
--- a/.github/workflows/detect-and-release-skills.yml
+++ b/.github/workflows/detect-and-release-skills.yml
@@ -286,6 +286,7 @@ jobs:
               const latest = await put('skills/' + skill + '/latest.zip', file, {
                 access: 'public',
                 addRandomSuffix: false,
+                allowOverwrite: true,
               });
               console.log('Uploaded latest:', latest.url);
 
@@ -293,6 +294,7 @@ jobs:
               const versioned = await put('skills/' + skill + '/v' + version + '.zip', file, {
                 access: 'public',
                 addRandomSuffix: false,
+                allowOverwrite: true,
               });
               console.log('Uploaded versioned:', versioned.url);
             }


### PR DESCRIPTION
Adds allowOverwrite: true to Vercel Blob put() calls to prevent BlobError when uploading skill packages on subsequent releases. The latest.zip file is always overwritten, so allowOverwrite is required. This also handles cases where versioned uploads are retried.