### PR TITLE
docs: add geographic performance best practices to Google Ads skill

### DIFF
--- a/hopkin-google-ads/skills/hopkin-google-ads/SKILL.md
+++ b/hopkin-google-ads/skills/hopkin-google-ads/SKILL.md
@@ -108,6 +108,7 @@ Some Google Ads users manage multiple client accounts through a Manager (MCC) ac
 
 ### Analytics
 - `google_ads_get_performance_report` — **Recommended.** Full-funnel report with funnel metrics (impressions, clicks, cost, ROAS) plus conversion breakdown by conversion action name — runs two queries in parallel
+- `google_ads_get_geo_performance` — Geographic performance breakdown by country, city, region, metro, or other geo levels. Uses `geographic_view` resource with automatic geo name resolution. Runs a parallel conversion breakdown query. **Only tool that supports geographic segments** — do not use `google_ads_get_insights` for geo data.
 - `google_ads_get_insights` — Custom analytics: full control over metrics, segments, and GAQL; use when `google_ads_get_performance_report` does not cover the required custom query
 
 ### Conversion Actions
@@ -135,10 +136,11 @@ This skill supports four primary report types and a developer feedback workflow 
 
 ### Report Types
 
-1. **Campaign Performance Reports** — Overall campaign metrics, spending, ROAS, and performance analysis
-2. **Keyword Analysis Reports** — Keyword performance, quality scores, search terms, and optimization opportunities
-3. **Ad Performance Reports** — Individual ad performance, RSA analysis, and creative effectiveness
-4. **Budget & Spend Reports** — Budget tracking, spend pacing, cost analysis, and forecasting
+1. **Geographic Performance Reports** — Location-based performance by country, city, region, metro, or other geo levels
+2. **Campaign Performance Reports** — Overall campaign metrics, spending, ROAS, and performance analysis
+3. **Keyword Analysis Reports** — Keyword performance, quality scores, search terms, and optimization opportunities
+4. **Ad Performance Reports** — Individual ad performance, RSA analysis, and creative effectiveness
+5. **Budget & Spend Reports** — Budget tracking, spend pacing, cost analysis, and forecasting
 
 ### Write Operations (Unsupported — Developer Feedback)
 
@@ -169,6 +171,16 @@ This helps the Hopkin team prioritize building tools that make common workflows 
 Users can provide feedback about this skill directly through the Hopkin Google Ads MCP. If a user wants to suggest improvements, report issues, or request new capabilities, call `google_ads_developer_feedback` on their behalf with the appropriate `feedback_type` (`new_tool`, `improvement`, `bug`, or `workflow_gap`) and include their feedback in the `description`.
 
 ## Report Workflows
+
+### Geographic Performance Report
+
+Analyze campaign performance across geographic locations — countries, cities, regions, metros, and more. Identify top-performing geographies, underperforming regions, and geo-targeting opportunities.
+
+**Primary tool:** `google_ads_get_geo_performance` — dedicated tool for geographic data using the `geographic_view` resource with automatic geo name resolution
+
+**See detailed workflow:** **references/workflows/geo-performance.md**
+
+---
 
 ### Campaign Performance Report
 
@@ -235,6 +247,14 @@ Choose metrics appropriate to campaign goal:
 - **Conversions:** Conversions, conversion value, ROAS, cost per conversion, conversion rate
 - **Keywords:** Quality score, search impression share, top-of-page rate
 
+### Geographic Analysis Best Practices
+
+- **Use the dedicated tool:** Geographic segments (`geo_target_city`, `geo_target_region`, etc.) are only available on the `geographic_view` resource. Always use `google_ads_get_geo_performance` — never attempt geographic breakdowns via `google_ads_get_insights`.
+- **One geo level per query:** Combining multiple geo levels (e.g., country + city) in a single query causes silent data loss in the Google Ads API. Run separate queries for each geo level.
+- **Mind the location type:** Results include both `LOCATION_OF_PRESENCE` (user physically there) and `AREA_OF_INTEREST` (user searching about the location). Distinguish between these when making targeting recommendations — physical presence is more reliable for local businesses.
+- **Use campaign filters for granularity:** At city/metro level, data can be sparse. Filter to a specific `campaign_id` to reduce noise and focus the analysis.
+- **Limit appropriately:** Sub-country geo levels can return many rows. Use the `limit` parameter (up to 200) and note that results are ordered by cost descending by default, surfacing the highest-spend locations first.
+
 ### Customer ID Formatting
 
 **CRITICAL:** Google Ads customer IDs must be without hyphens:
@@ -286,12 +306,13 @@ For more detailed information:
 - **references/mcp-tools-reference.md** — Complete Hopkin MCP tool documentation, parameters, and usage examples
 - **references/troubleshooting.md** — Comprehensive error solutions and debugging steps
 - **references/workflows/campaign-performance.md** — Detailed campaign performance report workflow
+- **references/workflows/geo-performance.md** — Detailed geographic performance report workflow
 - **references/workflows/keyword-analysis.md** — Detailed keyword analysis report workflow
 - **references/workflows/ad-performance.md** — Detailed ad performance report workflow
 - **references/workflows/budget-spend.md** — Detailed budget & spend report workflow
 
 ---
 
-**Skill Version:** 2.0
-**Last Updated:** 2026-02-10
+**Skill Version:** 2.1
+**Last Updated:** 2026-02-24
 **Requires:** Hopkin Google Ads MCP (https://app.hopkin.ai)

--- a/hopkin-google-ads/skills/hopkin-google-ads/references/mcp-tools-reference.md
+++ b/hopkin-google-ads/skills/hopkin-google-ads/references/mcp-tools-reference.md
@@ -283,8 +283,71 @@ This tool runs two parallel queries:
 
 ---
 
+#### google_ads_get_geo_performance
+Geographic performance breakdown using the `geographic_view` resource. This is the **only tool that supports geographic segments** — do not use `google_ads_get_insights` for geo data. Runs two parallel queries: geographic metrics + conversion breakdown (with graceful degradation). Location criterion IDs are automatically resolved to human-readable names.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `customer_id` (string, required) — Google Ads customer ID
+- `login_customer_id` (string, optional) — Manager account ID. Required when the target account is managed by an MCC
+- `date_preset` (string) — Date range preset (e.g., `"LAST_7_DAYS"`, `"LAST_30_DAYS"`, `"THIS_MONTH"`). Required if `date_range` not provided.
+- `date_range` (object) — Custom date range with `start_date` and `end_date` (YYYY-MM-DD). Required if `date_preset` not provided.
+- `geo_level` (string, optional) — Geographic granularity (default: `"country"`). Options: `"country"`, `"geo_target_city"`, `"geo_target_region"`, `"geo_target_state"`, `"geo_target_metro"`, `"geo_target_province"`, `"geo_target_county"`, `"geo_target_district"`, `"geo_target_most_specific_location"`, `"geo_target_postal_code"`, `"geo_target_airport"`, `"geo_target_canton"`. **Only one geo level per query** — combining levels causes silent data loss.
+- `level` (string, optional) — Aggregation level: `"ACCOUNT"`, `"CAMPAIGN"` (default), `"AD_GROUP"`
+- `segments` (array of strings, optional) — Non-geo segments: `"date"`, `"device"`, `"ad_network_type"`
+- `campaign_id` (string, optional) — Filter to a specific campaign
+- `ad_group_id` (string, optional) — Filter to a specific ad group
+- `limit` (number, optional) — Max results (1–200, default 50)
+
+**Returns:**
+- `data` — Geographic performance rows with resolved location names
+- `conversion_breakdown` — Per-entity, per-conversion-action metrics
+- `count`, `geo_level`, `level`, `date_range`/`date_preset`, `fetched_at` — Metadata
+
+**Example — Country-level by campaign:**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "Analyzing geographic performance by country",
+    "customer_id": "1234567890",
+    "date_preset": "LAST_7_DAYS"
+  }
+}
+```
+
+**Example — City-level for specific campaign:**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "City-level breakdown for Brand Search campaign",
+    "customer_id": "1234567890",
+    "campaign_id": "123456789",
+    "geo_level": "geo_target_city",
+    "date_preset": "LAST_30_DAYS",
+    "limit": 100
+  }
+}
+```
+
+**Example — Daily country trends:**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "Daily geographic trends by country",
+    "customer_id": "1234567890",
+    "date_preset": "LAST_7_DAYS",
+    "segments": ["date"]
+  }
+}
+```
+
+---
+
 #### google_ads_get_insights
-Custom analytics with full control over metrics, segments, and GAQL. Use when `google_ads_get_performance_report` does not cover the required query (e.g., custom metric selection, specialized segments, or conversion action segments).
+Custom analytics with full control over metrics, segments, and GAQL. Use when `google_ads_get_performance_report` does not cover the required query (e.g., custom metric selection, specialized segments, or conversion action segments). **Note:** Geographic segments are not available through this tool — use `google_ads_get_geo_performance` instead.
 
 **Parameters:**
 - `reason` (string, required) — Reason for the call
@@ -591,26 +654,36 @@ Submit feedback or feature requests to the Hopkin development team. Use this too
 3. Identify top performers, underperformers, and negative keyword candidates
 4. Provide keyword optimization recommendations
 
-### Pattern 3: Ad Creative Analysis
+### Pattern 3: Geographic Performance Analysis
+**Workflow:**
+1. Use `google_ads_get_geo_performance` with `geo_level: "country"` for a high-level geographic overview
+2. Drill into specific geographies with `geo_level: "geo_target_city"` or `"geo_target_metro"` filtered by `campaign_id`
+3. Compare LOCATION_OF_PRESENCE vs AREA_OF_INTEREST performance
+4. Identify high-spend, low-conversion geographies as exclusion candidates
+5. Recommend geo bid adjustments based on CPA/ROAS differences across locations
+
+**Important:** Only one geo level per query. Do not use `google_ads_get_insights` for geographic data.
+
+### Pattern 4: Ad Creative Analysis
 **Workflow:**
 1. Use `google_ads_list_ads` to get ads for a campaign
 2. Use `google_ads_get_insights` with `level: "AD"` for ad-level metrics
 3. Compare creative variations and identify top performers
 
-### Pattern 4: Budget & Spend Analysis
+### Pattern 5: Budget & Spend Analysis
 **Workflow:**
 1. Use `google_ads_list_campaigns` for budget data
 2. Use `google_ads_get_insights` with `segments: ["date"]` for daily spend trends
 3. Calculate pacing metrics
 4. Recommend budget adjustments
 
-### Pattern 5: Write Operation Requested (Developer Feedback)
+### Pattern 6: Write Operation Requested (Developer Feedback)
 **Workflow:**
 1. Inform the user that write operations are not yet available via Hopkin
 2. Call `google_ads_developer_feedback` with `feedback_type: "workflow_gap"`
 3. Provide guidance on how to perform the action manually via Google Ads
 
-### Pattern 6: Proactive Efficiency Feedback
+### Pattern 7: Proactive Efficiency Feedback
 **When:** After completing any task where you believe a faster path should have existed — e.g., you needed multiple calls that could have been one, had to manually compute something the tool could return, or a dedicated tool for the workflow was missing.
 
 **Workflow:**
@@ -682,6 +755,6 @@ Hopkin tools use cursor-based pagination:
 
 ---
 
-**Document Version:** 2.0
-**Last Updated:** 2026-02-10
+**Document Version:** 2.1
+**Last Updated:** 2026-02-24
 **Service:** Hopkin Google Ads MCP (https://app.hopkin.ai)

--- a/hopkin-google-ads/skills/hopkin-google-ads/references/workflows/geo-performance.md
+++ b/hopkin-google-ads/skills/hopkin-google-ads/references/workflows/geo-performance.md
@@ -1,0 +1,130 @@
+# Geographic Performance Report
+
+## Overview
+Analyze how campaigns perform across different geographic locations — countries, cities, regions, metros, states, and more. Identify top-performing geographies, spot underperforming regions, and inform geo-targeting decisions.
+
+## Primary Tool
+Use `google_ads_get_geo_performance` for all geographic analysis. This is a dedicated tool that queries the `geographic_view` resource, which is the **only** resource that supports geographic segments. Do NOT attempt to get geographic data through `google_ads_get_insights` — it will not work.
+
+Like `google_ads_get_performance_report`, this tool runs two parallel queries:
+1. **Geographic metrics** — impressions, clicks, cost, CTR, avg CPC, conversions, conversion value, cost per conversion, broken down by location
+2. **Conversion breakdown** — per-conversion-action metrics grouped by entity, with graceful degradation if the secondary query fails
+
+Location criterion IDs are automatically resolved to human-readable names (e.g., `2840` → `"United States"`, `geoTargetConstants/1014044` → `"San Francisco"`).
+
+## Required Parameters
+- **customer_id**: Google Ads account ID (format: 1234567890, no hyphens)
+- **Date range**: Use `date_preset` (e.g., `"LAST_30_DAYS"`) or `date_range` with `start_date` and `end_date`
+
+## Geo Levels
+
+The `geo_level` parameter controls the geographic granularity. Only **one geo level per query** — combining geo levels causes silent data loss in the API.
+
+| Geo Level | Description | Use When |
+|-----------|-------------|----------|
+| `country` (default) | Country-level breakdown | International accounts, market comparison |
+| `geo_target_region` | Region/state-level | National campaigns, regional performance |
+| `geo_target_state` | State-level | US-focused state analysis |
+| `geo_target_metro` | Metro/DMA area | Urban market analysis |
+| `geo_target_city` | City-level | Local campaigns, city targeting |
+| `geo_target_postal_code` | Postal/ZIP code | Hyperlocal analysis |
+| `geo_target_most_specific_location` | Most granular available | Maximum geographic detail |
+
+Additional levels: `geo_target_province`, `geo_target_county`, `geo_target_district`, `geo_target_airport`, `geo_target_canton`
+
+## Using google_ads_get_geo_performance
+
+**Country-level by campaign (default):**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "Analyzing geographic performance by country for last 7 days",
+    "customer_id": "1234567890",
+    "date_preset": "LAST_7_DAYS"
+  }
+}
+```
+
+**City-level for a specific campaign:**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "City-level breakdown for Brand Search campaign",
+    "customer_id": "1234567890",
+    "campaign_id": "123456789",
+    "geo_level": "geo_target_city",
+    "date_preset": "LAST_30_DAYS",
+    "limit": 100
+  }
+}
+```
+
+**Daily country trends:**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "Daily geographic trends by country",
+    "customer_id": "1234567890",
+    "date_preset": "LAST_7_DAYS",
+    "segments": ["date"]
+  }
+}
+```
+
+**Account-level metro breakdown:**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "Metro area performance across all campaigns",
+    "customer_id": "1234567890",
+    "level": "ACCOUNT",
+    "geo_level": "geo_target_metro",
+    "date_preset": "LAST_30_DAYS"
+  }
+}
+```
+
+**MCC managed account:**
+```json
+{
+  "tool": "google_ads_get_geo_performance",
+  "parameters": {
+    "reason": "Geographic performance for MCC-managed client",
+    "customer_id": "1234567890",
+    "login_customer_id": "9999999999",
+    "date_preset": "LAST_30_DAYS"
+  }
+}
+```
+
+## Location Type
+
+Results include a `location_type` field with two possible values:
+- **LOCATION_OF_PRESENCE** — The user was physically in this location
+- **AREA_OF_INTEREST** — The user showed interest in this location (e.g., searched for "hotels in Paris" from New York)
+
+When analyzing geographic data, note both types. LOCATION_OF_PRESENCE is more reliable for local business targeting; AREA_OF_INTEREST captures demand signals from users elsewhere.
+
+## Output Formatting
+
+Present results in a table format:
+
+| Country | Campaign | Location Type | Impr. | Clicks | Cost | CTR | Conv. | Conv. Value | CPA |
+|---------|----------|---------------|-------|--------|------|-----|-------|-------------|-----|
+| [name] | [name] | [type] | [n] | [n] | $[n] | [n]% | [n] | $[n] | $[n] |
+
+For sub-country levels, replace the "Country" column with the appropriate geo level (City, Region, Metro, etc.).
+
+## Insights to Provide
+
+After presenting geographic data, analyze:
+1. **Top geographies**: Locations with highest conversion volume or best ROAS
+2. **Cost efficiency**: Compare CPA across locations — identify geographies where cost per conversion is significantly above or below average
+3. **Opportunity areas**: Locations with high impressions but low conversions (possible landing page or targeting issues)
+4. **Waste identification**: Locations with spend but zero or near-zero conversions — candidates for geo exclusions
+5. **Location type split**: If both LOCATION_OF_PRESENCE and AREA_OF_INTEREST appear, compare performance between them
+6. **Recommendations**: Suggest bid adjustments, geo exclusions, or expanded targeting based on findings


### PR DESCRIPTION
## Summary

Added comprehensive documentation and best practices for the new `google_ads_get_geo_performance` tool to the @hopkin-google-ads skill. Geographic performance reports now appear as the primary report type due to their frequency of use.

**Key additions:**
- Full `google_ads_get_geo_performance` tool reference with all 12 geo levels, parameters, and usage examples
- Dedicated geo-performance workflow guide covering location types, output formatting, and analysis insights
- Geographic analysis best practices emphasizing the dedicated tool requirement, single-query-per-geo-level pattern, and location type interpretation
- New geographic performance analysis usage pattern in the MCP tools reference

**Implementation highlights from the MCP:**
- Tool uses `geographic_view` resource (only resource supporting geographic segments)
- Runs parallel conversion breakdown queries with graceful degradation
- Automatically resolves criterion IDs to human-readable names
- Supports 12 geo levels from country down to postal code/airport/canton

Versions bumped to 2.1, documentation updated to reflect February 2026 changes.