### PR TITLE
Update hopkin-meta-ads skill for creative report tool

### DIFF
--- a/hopkin-meta-ads/skills/hopkin-meta-ads/SKILL.md
+++ b/hopkin-meta-ads/skills/hopkin-meta-ads/SKILL.md
@@ -109,7 +109,8 @@ When `meta_ads_list_ad_accounts` returns multiple accounts:
 - `meta_ads_list_ads` — List ads for an account, campaign, or ad set (supports status filter, name search, lookup by ID, pagination)
 
 ### Analytics
-- `meta_ads_get_performance_report` — **Recommended.** Full-funnel performance report (always includes impressions, reach, frequency, spend, clicks, cpc, cpm, ctr, unique_clicks, actions, action_values, conversions, purchase_roas, quality rankings). Requires `time_range` with explicit since/until dates.
+- `meta_ads_get_performance_report` — **Recommended for campaign/account/adset-level analysis.** Full-funnel performance report (always includes impressions, reach, frequency, spend, clicks, cpc, cpm, ctr, unique_clicks, actions, action_values, conversions, purchase_roas, quality rankings). Requires `time_range` with explicit since/until dates. Supports `level`: account (default), campaign, adset, ad.
+- `meta_ads_get_ad_creative_report` — **Recommended for ad creative analysis.** Ad-level performance report with full funnel metrics and creative asset info (asset_type, asset_url, thumbnail_url). Supports two grouping modes via `level`: `ad_name` (default, aggregates ads with the same name across ad sets — returns a representative ad_id usable with `meta_ads_preview_ads`) or `ad_id` (one row per ad). Use this instead of `meta_ads_get_performance_report` with `level: "ad"` for creative analysis.
 - `meta_ads_get_insights` — Flexible insights with custom breakdowns, metrics, and date presets
 
 ### Creative
@@ -180,7 +181,7 @@ Analyze overall campaign performance, compare campaigns across an account, ident
 
 Evaluate individual ad creative effectiveness, conduct A/B testing analysis, identify best-performing ad formats, and preview actual ad creatives with performance data.
 
-**Primary tools:** `meta_ads_get_performance_report` with `level: "ad"` + `meta_ads_preview_ads`
+**Primary tools:** `meta_ads_get_ad_creative_report` + `meta_ads_preview_ads`
 
 **See detailed workflow:** **references/workflows/ad-creative-performance.md**
 
@@ -297,6 +298,6 @@ For more detailed information:
 
 ---
 
-**Skill Version:** 2.0
-**Last Updated:** 2026-02-10
+**Skill Version:** 2.1
+**Last Updated:** 2026-03-04
 **Requires:** Hopkin Meta Ads MCP (https://app.hopkin.ai)

--- a/hopkin-meta-ads/skills/hopkin-meta-ads/references/mcp-tools-reference.md
+++ b/hopkin-meta-ads/skills/hopkin-meta-ads/references/mcp-tools-reference.md
@@ -186,18 +186,17 @@ List ads for an account, campaign, or ad set. Supports adset filtering, status f
 ### Analytics Tools
 
 #### meta_ads_get_performance_report
-**Recommended for most reporting use cases.** Returns a comprehensive performance funnel with pre-built metrics.
+**Recommended for account, campaign, and adset-level reporting.** Returns a comprehensive performance funnel with pre-built metrics.
 
-This tool always includes a full funnel of metrics: impressions, reach, frequency, spend, clicks, cpc, cpm, ctr, unique_clicks, actions, action_values, conversions, purchase_roas, and quality rankings. Use `meta_ads_get_insights` if you need date presets or custom fields.
+This tool always includes a full funnel of metrics: impressions, reach, frequency, spend, clicks, cpc, cpm, ctr, unique_clicks, actions, action_values, conversions, purchase_roas, and quality rankings. Use `meta_ads_get_insights` if you need date presets or custom fields. **For ad creative analysis, use `meta_ads_get_ad_creative_report` instead.**
 
 **Parameters:**
 - `reason` (string, required) — Reason for the call
 - `account_id` (string, required) — Ad account ID
 - `time_range` (object, required) — Date range with `since` and `until` (YYYY-MM-DD format)
 - `level` (string, optional) — Aggregation level: `"account"` (default), `"campaign"`, `"adset"`, or `"ad"`
-- `time_increment` (number or string, optional) — Time grouping: `1` for daily, `7` for weekly, `"monthly"`
-- `breakdowns` (array, optional) — Segment data by dimension (e.g., `["age", "gender"]`)
-- `action_breakdowns` (array, optional) — Action breakdown dimensions
+- `time_increment` (number or string, optional) — Time grouping: `1` for daily, `7` for weekly, `"monthly"`, `"all_days"` for a single row over the entire range
+- `breakdowns` (array, optional) — Segment data by dimension (e.g., `["age", "gender"]`). Pass multiple values in a single call to get cross-tabulated rows — do NOT make separate calls per dimension.
 - `filtering` (array, optional) — Filters as `[{field, operator, value}]`
 
 **Example:**
@@ -209,6 +208,60 @@ This tool always includes a full funnel of metrics: impressions, reach, frequenc
     "account_id": "act_123456789",
     "level": "campaign",
     "time_range": {"since": "2026-01-01", "until": "2026-01-31"}
+  }
+}
+```
+
+#### meta_ads_get_ad_creative_report
+**Recommended for ad creative analysis.** Ad-level performance report with full funnel metrics and creative asset information (type, URL, thumbnail). Use this instead of `meta_ads_get_performance_report` with `level: "ad"` for any creative analysis workflow.
+
+Supports two grouping modes via the `level` parameter:
+- **`ad_name`** (default): aggregates all ads sharing the same name across ad sets, returns a representative `ad_id` (highest impressions) that can be passed directly to `meta_ads_preview_ads` — ideal for comparing the same creative running in multiple ad sets. Omits non-aggregatable fields (`frequency`, quality rankings, ROAS).
+- **`ad_id`**: one row per ad — use when comparing distinct individual ads.
+
+All conversion types are shown individually, not collapsed into a single number. Always fetches fresh data.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, required) — Ad account ID
+- `time_range` (object, required) — Date range with `since` and `until` (YYYY-MM-DD format)
+- `level` (string, optional) — Grouping mode: `"ad_name"` (default) or `"ad_id"`
+- `time_increment` (number or string, optional) — Time grouping: `1` for daily, `7` for weekly, `"monthly"`, `"all_days"` for a single row over the entire range
+- `breakdowns` (array, optional) — Segment data by dimension (e.g., `["age", "gender"]`). Available: age, gender, country, region, device_platform, publisher_platform, platform_position, impression_device, dma
+- `filtering` (array, optional) — Filters as `[{field, operator, value}]`
+
+**Returns:**
+- `ad_id` — the ad ID (or representative ad_id in `ad_name` mode)
+- `ad_name` — the ad name
+- `ad_count` — number of ads aggregated (only in `ad_name` mode)
+- `asset_type` — `'image'` | `'video'` | `'unknown'`
+- `asset_url` — GCS URL to the creative asset
+- `thumbnail_url` — GCS URL to thumbnail (videos only)
+- Full delivery, engagement, action, and conversion metrics
+
+**Example — Creative round analysis by name:**
+```json
+{
+  "tool": "meta_ads_get_ad_creative_report",
+  "parameters": {
+    "reason": "Getting creative performance for round analysis",
+    "account_id": "act_123456789",
+    "level": "ad_name",
+    "time_range": {"since": "2026-01-01", "until": "2026-01-31"}
+  }
+}
+```
+
+**Example — Individual ad comparison:**
+```json
+{
+  "tool": "meta_ads_get_ad_creative_report",
+  "parameters": {
+    "reason": "Comparing individual ads for A/B analysis",
+    "account_id": "act_123456789",
+    "level": "ad_id",
+    "time_range": {"since": "2026-01-01", "until": "2026-01-31"},
+    "filtering": [{"field": "campaign.id", "operator": "EQUAL", "value": "123456789"}]
   }
 }
 ```
@@ -263,7 +316,7 @@ Flexible insights tool for custom metric and breakdown combinations. Supports da
 #### meta_ads_preview_ads
 **MCP App** — Renders a visual UI with actual ad creative content (images/videos) and a configurable metrics overlay. This is distinct from tabular data tools: it returns an interactive visual panel, not a data table. Proactively offer this whenever the user asks "what do my ads look like", wants to review creative quality, or is doing A/B creative comparison.
 
-You must first retrieve ad IDs (via `meta_ads_list_ads`) and their metrics (via `meta_ads_get_performance_report` or `meta_ads_get_insights`), then pass them to this tool.
+Use `meta_ads_get_ad_creative_report` to get ad metrics and representative ad IDs in a single call, then pass them to this tool. The `ad_id` values from the creative report (including representative IDs in `ad_name` mode) work directly here — no separate `meta_ads_list_ads` call needed.
 
 **Parameters:**
 - `reason` (string, required) — Reason for the call
@@ -455,12 +508,11 @@ Submit feedback or feature requests to the Hopkin development team. Use this too
 
 ### Pattern 2: Ad Creative Analysis with Preview
 **Workflow:**
-1. Use `meta_ads_list_ads` to get ads for a campaign or ad set — collect ad IDs
-2. Use `meta_ads_get_performance_report` with `level: "ad"` for ad-level metrics — collect spend, CTR, CPA etc. per ad ID
-3. Use `meta_ads_preview_ads` with the collected ad IDs and metrics to render the visual creative UI with metrics overlay
-4. Compare creative variations and identify top performers
+1. Use `meta_ads_get_ad_creative_report` with `level: "ad_name"` (default) to get creative metrics and representative ad IDs in a single call — no need to first call `meta_ads_list_ads`
+2. Use `meta_ads_preview_ads` with the `ad_id` values from the creative report and their metrics to render the visual creative UI with metrics overlay
+3. Compare creative variations and identify top performers
 
-> `meta_ads_preview_ads` requires ad IDs — you must call `meta_ads_list_ads` first to obtain them. It does not accept `campaign_id` or `adset_id` directly.
+> In `ad_name` mode, `meta_ads_get_ad_creative_report` returns a representative `ad_id` per creative name that can be passed directly to `meta_ads_preview_ads`. Use `level: "ad_id"` if you need to compare distinct individual ads rather than aggregated creative names.
 
 ### Pattern 3: Demographic / Audience Analysis
 **Workflow:**
@@ -585,6 +637,6 @@ Hopkin list tools use cursor-based pagination:
 
 ---
 
-**Document Version:** 2.0
-**Last Updated:** 2026-02-10
+**Document Version:** 2.1
+**Last Updated:** 2026-03-04
 **Service:** Hopkin Meta Ads MCP (https://app.hopkin.ai)

--- a/hopkin-meta-ads/skills/hopkin-meta-ads/references/workflows/ad-creative-performance.md
+++ b/hopkin-meta-ads/skills/hopkin-meta-ads/references/workflows/ad-creative-performance.md
@@ -13,10 +13,10 @@ This workflow is particularly useful when:
 
 ## Primary Tools
 
-- `meta_ads_get_performance_report` with `level: "ad"` — Get ad-level performance metrics (recommended, includes full funnel)
-- `meta_ads_get_insights` with `level: "ad"` — For custom breakdowns at ad level
-- `meta_ads_preview_ads` — **Crown jewel of creative reporting.** An MCP App that renders a visual UI showing actual ad images/videos with a configurable metrics overlay — not tabular data. This is the definitive way to review creative quality. Proactively offer it whenever the user asks "what do my ads look like", wants to review creative quality, is doing A/B creative comparison, or when presenting winners/losers. Requires ad IDs from `meta_ads_list_ads` and optional metrics from the performance tools.
-- `meta_ads_list_ads` — List ads for a campaign or ad set (use to collect ad IDs before calling `meta_ads_preview_ads`)
+- `meta_ads_get_ad_creative_report` — **Recommended for creative analysis.** Ad-level performance report with full funnel metrics plus creative asset info (asset_type, asset_url, thumbnail_url). Use `level: "ad_name"` (default) to aggregate ads by name across ad sets — returns a representative `ad_id` per creative that can be passed directly to `meta_ads_preview_ads`. Use `level: "ad_id"` to compare distinct individual ads.
+- `meta_ads_preview_ads` — **Crown jewel of creative reporting.** An MCP App that renders a visual UI showing actual ad images/videos with a configurable metrics overlay — not tabular data. This is the definitive way to review creative quality. Proactively offer it whenever the user asks "what do my ads look like", wants to review creative quality, is doing A/B creative comparison, or when presenting winners/losers. The `ad_id` values from `meta_ads_get_ad_creative_report` can be passed directly — no need to call `meta_ads_list_ads` first.
+- `meta_ads_get_insights` with `level: "ad"` — For custom fields or breakdowns not available in the creative report
+- `meta_ads_list_ads` — Use only if you need to look up specific ad IDs before running `meta_ads_get_ad_creative_report` with `level: "ad_id"` filtering
 
 ## Required Information
 
@@ -111,28 +111,28 @@ Before starting this workflow, gather:
 **Steps:**
 
 1. **Export ad-level data using Hopkin MCP tools:**
-   - Use `meta_ads_get_performance_report` with `level: "ad"` for comprehensive ad-level metrics:
+   - Use `meta_ads_get_ad_creative_report` for comprehensive ad-level metrics with creative asset info:
      ```json
      {
-       "tool": "meta_ads_get_performance_report",
+       "tool": "meta_ads_get_ad_creative_report",
        "parameters": {
-         "reason": "Getting ad-level performance data for creative test analysis",
+         "reason": "Getting creative performance data for creative test analysis",
          "account_id": "act_123456789",
-         "level": "ad",
-         "time_range": {"since": "2026-01-01", "until": "2026-01-31"},
-         "campaign_id": "123456789"
+         "level": "ad_name",
+         "time_range": {"since": "2026-01-01", "until": "2026-01-31"}
        }
      }
      ```
-   - Or use `meta_ads_get_insights` for custom metrics/breakdowns at ad level
-   - Include these core fields:
-     - **Ad Details:** ad_name, ad_id, creative_id, adset_name, campaign_name
-     - **Creative Type:** creative_type (video, image, carousel, etc.)
-     - **Engagement:** impressions, reach, clicks, ctr, cpc
+   - Use `level: "ad_name"` (default) to aggregate ads sharing the same name across ad sets — the response includes a representative `ad_id` per creative for use with `meta_ads_preview_ads`
+   - Use `level: "ad_id"` if you need one row per individual ad
+   - Use `meta_ads_get_insights` only for custom fields or breakdowns not available in the creative report
+   - The response includes these fields automatically:
+     - **Ad Details:** ad_id, ad_name, ad_count (ad_name mode only)
+     - **Creative Asset:** asset_type (image/video/unknown), asset_url (GCS URL), thumbnail_url (GCS URL, videos only)
+     - **Engagement:** impressions, reach, clicks, ctr, cpc, cpm
      - **Spend:** spend
-     - **Primary Conversion:** The conversion event aligned with your primary metric (purchases, leads, trials, etc.)
-     - **Cost per Primary Conversion:** CPA, CPL, or cost per acquisition for primary metric
-     - **Secondary Events:** Any additional metrics requested (video plays, add-to-cart, etc.)
+     - **All conversion types** individually with counts, costs, and values
+     - **Secondary Events:** All action types with counts and values
 
 2. **Pull additional creative metadata from Motion or BI (if available):**
    - Creative tags (concept names, hook types, angles, offers)
@@ -164,7 +164,7 @@ Before starting this workflow, gather:
 
 1. **Get creative previews via Hopkin:**
    - `meta_ads_preview_ads` is an MCP App that renders actual visual ad creative (images/videos) with a metrics overlay in an interactive UI — distinct from tabular data tools. It is the definitive way to let stakeholders see what the ads look like. Proactively offer it in any creative review context.
-   - First, collect ad IDs from `meta_ads_list_ads` and metrics from `meta_ads_get_performance_report` or `meta_ads_get_insights`, then pass them together:
+   - The `ad_id` values returned by `meta_ads_get_ad_creative_report` (including representative IDs in `ad_name` mode) can be passed directly — no need to call `meta_ads_list_ads` separately:
      ```json
      {
        "tool": "meta_ads_preview_ads",
@@ -179,7 +179,7 @@ Before starting this workflow, gather:
        }
      }
      ```
-   - For video ads, get both the video file and a thumbnail/poster frame
+   - For video ads, get both the video file and a thumbnail/poster frame. The `thumbnail_url` field in the creative report response provides a GCS-hosted thumbnail.
 
 2. **Download assets for key creatives:**
    - **Download all winners** - Essential to show what worked
@@ -668,39 +668,41 @@ For video ads, include additional video performance metrics:
 
 ## Best Practices
 
-1. **ALWAYS use `meta_ads_preview_ads` for creative review** — This MCP App renders a visual UI with actual images/videos and metrics side-by-side. It is the most powerful tool in this workflow. Use it:
+1. **ALWAYS use `meta_ads_get_ad_creative_report` as the primary data source** — This is the dedicated tool for creative analysis. Use `level: "ad_name"` (default) to compare creative concepts across ad sets; use `level: "ad_id"` for individual ad comparisons. The returned `ad_id` values work directly with `meta_ads_preview_ads`.
+
+2. **ALWAYS use `meta_ads_preview_ads` for creative review** — This MCP App renders a visual UI with actual images/videos and metrics side-by-side. It is the most powerful tool in this workflow. Use it:
    - Whenever the user asks "what do my ads look like" or wants to review creative
    - When presenting winners and losers — visual context makes insights actionable
    - For A/B creative comparisons — seeing the creative alongside the number is essential
-   - Always pull ad IDs with `meta_ads_list_ads` and metrics with the performance report first, then pass them together to `meta_ads_preview_ads`
+   - Pass `ad_id` values from `meta_ads_get_ad_creative_report` directly — no need to call `meta_ads_list_ads` first
 
-2. **ALWAYS include creative visuals in reports** - Never present creative test results without showing the actual ads
+3. **ALWAYS include creative visuals in reports** - Never present creative test results without showing the actual ads
    - Winners and top losers must have images/videos included
    - For Notion: Download from Meta first, then upload to Notion (never use Meta URLs directly)
    - Stakeholders need to see what worked/failed, not just read metrics
    - Creative insights are meaningless without seeing the creative
 
-2. **Always confirm scope before pulling data** - Ambiguity leads to rework
+4. **Always confirm scope before pulling data** - Ambiguity leads to rework
 
-3. **Align on metrics early** - Primary metric should be clear from the start
+5. **Align on metrics early** - Primary metric should be clear from the start
 
-4. **Confirm output format upfront** - Ask what format they want (Notion, Slides, PDF, Excel) before building
+6. **Confirm output format upfront** - Ask what format they want (Notion, Slides, PDF, Excel) before building
 
-5. **Define benchmarks explicitly** - Don't rely on intuition for winner/loser calls
+7. **Define benchmarks explicitly** - Don't rely on intuition for winner/loser calls
 
-6. **Review actual creatives, not just numbers** - The "why" comes from watching the ads
+8. **Review actual creatives, not just numbers** - The "why" comes from watching the ads
    - Watch videos fully, don't just look at thumbnails
    - Note first 3 seconds (hook quality), messaging, visual style, CTA placement
 
-7. **Be specific in insights** - "Social proof hooks work" is weak; "3-item listicle hooks doubled CTR" is strong
+9. **Be specific in insights** - "Social proof hooks work" is weak; "3-item listicle hooks doubled CTR" is strong
    - Reference specific creative elements visible in the assets
 
-8. **Connect actions to expectations** - Tell the client what should happen next
+10. **Connect actions to expectations** - Tell the client what should happen next
 
-9. **QA rigorously** - Metric misalignment destroys credibility
-   - Verify all creative assets are displaying correctly before sharing
+11. **QA rigorously** - Metric misalignment destroys credibility
+    - Verify all creative assets are displaying correctly before sharing
 
-10. **Capture feedback for next time** - Every round should improve your process
+12. **Capture feedback for next time** - Every round should improve your process
 
 ## Common Pitfalls to Avoid
 


### PR DESCRIPTION
## Summary
Updated the @hopkin-meta-ads skill documentation to reflect the new `meta_ads_get_ad_creative_report` tool and changes to performance reporting tools. This tool provides dedicated ad creative analysis with creative asset metadata and two grouping modes (ad_name for concept analysis, ad_id for individual ad comparison).

## Changes
- Added `meta_ads_get_ad_creative_report` as the recommended tool for ad creative analysis with full parameter and return value documentation
- Removed `action_breakdowns` parameter from `meta_ads_get_performance_report` (no longer supported in latest MCP version)
- Added `all_days` option to `time_increment` parameter for performance reports
- Updated ad creative performance workflow to use the new dedicated tool instead of performance report with `level: "ad"`
- Simplified creative workflow by eliminating the need to call `meta_ads_list_ads` separately (ad IDs now returned directly from creative report)
- Updated best practices and examples throughout all three documentation files

## Files Changed
- `hopkin-meta-ads/skills/hopkin-meta-ads/SKILL.md` (version 2.0 → 2.1)
- `hopkin-meta-ads/skills/hopkin-meta-ads/references/mcp-tools-reference.md` (version 2.0 → 2.1)
- `hopkin-meta-ads/skills/hopkin-meta-ads/references/workflows/ad-creative-performance.md`