### PR TITLE
Fix LinkedIn plugin MCP server type and update icons

### DIFF
--- a/hopkin-linkedin-ads/.mcp.json
+++ b/hopkin-linkedin-ads/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "hopkin-linkedin-ads": {
-      "type": "url",
+      "type": "http",
       "url": "https://linkedin.mcp.hopkin.ai/mcp"
     }
   }


### PR DESCRIPTION
Changes in this PR:

- Fix LinkedIn plugin validation error by changing MCP server type from 'url' to 'http'
- Update all plugin icons (Google Ads, Meta Ads, LinkedIn Ads) to use the correct Hopkin logo

This resolves the sync error that appeared in the marketplace validation.