### PR TITLE
docs(meta-ads): document attributionWindows parameter support

### DIFF
--- a/hopkin-meta-ads/skills/hopkin-meta-ads/SKILL.md
+++ b/hopkin-meta-ads/skills/hopkin-meta-ads/SKILL.md
@@ -109,9 +109,9 @@ When `meta_ads_list_ad_accounts` returns multiple accounts:
 - `meta_ads_list_ads` — List ads for an account, campaign, or ad set (supports status filter, name search, lookup by ID, pagination)
 
 ### Analytics
-- `meta_ads_get_performance_report` — **Recommended for campaign/account/adset-level analysis.** Full-funnel performance report (always includes impressions, reach, frequency, spend, clicks, cpc, cpm, ctr, unique_clicks, actions, action_values, conversions, purchase_roas, quality rankings). Requires `time_range` with explicit since/until dates. Supports `level`: account (default), campaign, adset, ad.
+- `meta_ads_get_performance_report` — **Recommended for campaign/account/adset-level analysis.** Full-funnel performance report (always includes impressions, reach, frequency, spend, clicks, cpc, cpm, ctr, unique_clicks, actions, action_values, conversions, purchase_roas, quality rankings). Requires `time_range` with explicit since/until dates. Supports `level`: account (default), campaign, adset, ad. Supports `attributionWindows` to specify post-click and post-view attribution periods (e.g., `["1d_click", "7d_click", "1d_view"]`).
 - `meta_ads_get_ad_creative_report` — **Recommended for ad creative analysis.** Ad-level performance report with full funnel metrics and creative asset info (asset_type, asset_url, thumbnail_url). Supports two grouping modes via `level`: `ad_name` (default, aggregates ads with the same name across ad sets — returns a representative ad_id usable with `meta_ads_preview_ads`) or `ad_id` (one row per ad). Use this instead of `meta_ads_get_performance_report` with `level: "ad"` for creative analysis.
-- `meta_ads_get_insights` — Flexible insights with custom breakdowns, metrics, and date presets
+- `meta_ads_get_insights` — Flexible insights with custom breakdowns, metrics, and date presets. Supports `attributionWindows` to specify post-click and post-view attribution periods (e.g., `["1d_click", "7d_click", "1d_view"]`).
 
 ### Creative
 - `meta_ads_preview_ads` — **MCP App.** Renders a visual UI with actual ad creative (images/videos) and a configurable metrics overlay — not tabular data. Proactively offer this whenever the user asks "what do my ads look like", wants to review creative quality, or is doing A/B creative comparison. Takes a list of ad IDs with optional per-ad metric values.
@@ -246,6 +246,39 @@ Provide actionable optimization recommendations based on performance analysis:
 
 ## Best Practices
 
+### Attribution Windows
+
+Attribution windows define how long after an ad click or view a conversion is counted. Both `meta_ads_get_performance_report` and `meta_ads_get_insights` accept an `attributionWindows` array parameter.
+
+**Available values:**
+- `1d_click` — Conversions within 1 day of clicking
+- `7d_click` — Conversions within 7 days of clicking (Meta default)
+- `28d_click` — Conversions within 28 days of clicking
+- `1d_view` — Conversions within 1 day of viewing (without clicking)
+- `7d_view` — Conversions within 7 days of viewing (without clicking)
+
+**When to use custom attribution windows:**
+- Comparing campaign performance across different windows to understand conversion lag
+- Evaluating view-through contribution for brand/awareness campaigns (add `1d_view` or `7d_view`)
+- Matching a client's attribution setting to reconcile ROAS discrepancies
+- Benchmarking against the Meta platform default (7-day click)
+
+**Example — side-by-side attribution comparison:**
+```json
+{
+  "tool": "meta_ads_get_performance_report",
+  "parameters": {
+    "reason": "Comparing 1-day vs 7-day click attribution to understand conversion lag",
+    "account_id": "act_123456789",
+    "level": "campaign",
+    "time_range": {"since": "2026-01-01", "until": "2026-01-31"},
+    "attributionWindows": ["1d_click", "7d_click"]
+  }
+}
+```
+
+For full details see **references/mcp-tools-reference.md#attribution-windows**.
+
 ### Date Range Considerations
 
 - **Short-term (1-7 days):** Daily monitoring, recent changes, quick checks
@@ -315,6 +348,6 @@ For more detailed information:
 
 ---
 
-**Skill Version:** 2.2
-**Last Updated:** 2026-03-05
+**Skill Version:** 2.3
+**Last Updated:** 2026-03-13
 **Requires:** Hopkin Meta Ads MCP (https://app.hopkin.ai)

--- a/hopkin-meta-ads/skills/hopkin-meta-ads/references/mcp-tools-reference.md
+++ b/hopkin-meta-ads/skills/hopkin-meta-ads/references/mcp-tools-reference.md
@@ -7,10 +7,11 @@ This document provides detailed reference information for the Hopkin Meta Ads MC
 1. [MCP Server Overview](#mcp-server-overview)
 2. [Authentication & Connection](#authentication--connection)
 3. [Core Tools](#core-tools)
-4. [Tool Usage Patterns](#tool-usage-patterns)
-5. [Response Format](#response-format)
-6. [Pagination](#pagination)
-7. [Error Handling](#error-handling)
+4. [Attribution Windows](#attribution-windows)
+5. [Tool Usage Patterns](#tool-usage-patterns)
+6. [Response Format](#response-format)
+7. [Pagination](#pagination)
+8. [Error Handling](#error-handling)
 
 ---
 
@@ -181,6 +182,7 @@ This tool always includes a full funnel of metrics: impressions, reach, frequenc
 - `time_increment` (number or string, optional) — Time grouping: `1` for daily, `7` for weekly, `"monthly"`, `"all_days"` for a single row over the entire range
 - `breakdowns` (array, optional) — Segment data by dimension (e.g., `["age", "gender"]`). Pass multiple values in a single call to get cross-tabulated rows — do NOT make separate calls per dimension.
 - `filtering` (array, optional) — Filters as `[{field, operator, value}]`
+- `attributionWindows` (array, optional) — Attribution window settings that control how conversions are counted. Each value specifies a click or view window (e.g., `["1d_click", "7d_click", "1d_view"]`). When omitted, Meta uses the account's default attribution window. See [Attribution Windows](#attribution-windows) for full details.
 
 **Example:**
 ```json
@@ -263,6 +265,7 @@ Flexible insights tool for custom metric and breakdown combinations. Supports da
 - `breakdowns` (array, optional) — Breakdown dimensions (e.g., `["age", "gender"]`, `["country"]`, `["device_platform"]`)
 - `action_breakdowns` (array, optional) — Action breakdown dimensions
 - `filtering` (array, optional) — Filters as `[{field, operator, value}]`
+- `attributionWindows` (array, optional) — Attribution window settings that control how conversions are counted. Each value specifies a click or view window (e.g., `["1d_click", "7d_click", "1d_view"]`). When omitted, Meta uses the account's default attribution window. See [Attribution Windows](#attribution-windows) for full details.
 
 **Example — Demographic Breakdown:**
 ```json
@@ -580,6 +583,83 @@ Submit feedback or feature requests to the Hopkin development team. Use this too
 
 ---
 
+## Attribution Windows
+
+Attribution windows define the time period after an ad interaction (click or view) during which a conversion is counted and credited to that ad.
+
+### Why Attribution Windows Matter
+
+Different attribution windows can report significantly different conversion counts for the same campaign. A 7-day click window will include conversions that happened up to 7 days after clicking an ad, while a 1-day click window only counts same-day conversions. Comparing results across windows helps you understand:
+
+- **How quickly your customers convert** — A large gap between 1-day and 7-day click conversions suggests a longer consideration cycle
+- **The true impact of view-through conversions** — View windows reveal whether ad exposure (without a click) influences purchases
+- **Accurate ROAS comparisons** — Advertisers using different window settings may report very different ROAS numbers for equivalent campaigns
+
+### Available Window Values
+
+| Value | Description |
+|-------|-------------|
+| `1d_click` | Conversions within 1 day of clicking the ad |
+| `7d_click` | Conversions within 7 days of clicking the ad (Meta default) |
+| `28d_click` | Conversions within 28 days of clicking the ad |
+| `1d_view` | Conversions within 1 day of viewing (not clicking) the ad |
+| `7d_view` | Conversions within 7 days of viewing (not clicking) the ad |
+
+### Usage
+
+Pass one or more values as an array. When multiple windows are specified, Meta returns results for each window — enabling side-by-side comparison.
+
+**Example — Compare 1-day vs 7-day click attribution:**
+```json
+{
+  "tool": "meta_ads_get_performance_report",
+  "parameters": {
+    "reason": "Comparing 1-day and 7-day click attribution to understand conversion lag",
+    "account_id": "act_123456789",
+    "level": "campaign",
+    "time_range": {"since": "2026-01-01", "until": "2026-01-31"},
+    "attributionWindows": ["1d_click", "7d_click"]
+  }
+}
+```
+
+**Example — Include view-through attribution:**
+```json
+{
+  "tool": "meta_ads_get_insights",
+  "parameters": {
+    "reason": "Analyzing view-through contribution alongside click-through conversions",
+    "account_id": "act_123456789",
+    "level": "campaign",
+    "date_preset": "last_30d",
+    "attributionWindows": ["7d_click", "1d_view"]
+  }
+}
+```
+
+**Example — Full window comparison for client report:**
+```json
+{
+  "tool": "meta_ads_get_insights",
+  "parameters": {
+    "reason": "Full attribution window comparison for quarterly review",
+    "account_id": "act_123456789",
+    "level": "campaign",
+    "time_range": {"since": "2026-01-01", "until": "2026-03-31"},
+    "attributionWindows": ["1d_click", "7d_click", "28d_click", "1d_view"]
+  }
+}
+```
+
+### When to Use Custom Attribution Windows
+
+- **Benchmarking against industry standards** — Many advertisers use 7-day click as the standard; use this to match external benchmarks
+- **Understanding conversion lag** — Compare 1-day vs. 7-day click to see how many conversions happen after the first day
+- **Evaluating brand awareness campaigns** — Add `1d_view` or `7d_view` to measure view-through conversions for top-of-funnel campaigns
+- **Reconciling discrepancies** — If reported ROAS differs from what the client expects, check which attribution window their account uses and match it
+
+---
+
 ## Tool Usage Patterns
 
 ### Pattern 1: Account Overview & Performance Report
@@ -726,6 +806,6 @@ Hopkin list tools use cursor-based pagination:
 
 ---
 
-**Document Version:** 2.1
-**Last Updated:** 2026-03-04
+**Document Version:** 2.2
+**Last Updated:** 2026-03-13
 **Service:** Hopkin Meta Ads MCP (https://app.hopkin.ai)


### PR DESCRIPTION
## Summary

- Adds a new **Attribution Windows** section to `mcp-tools-reference.md` explaining what attribution windows are, the available values (`1d_click`, `7d_click`, `28d_click`, `1d_view`, `7d_view`), and when to use each
- Documents the `attributionWindows` parameter on both `meta_ads_get_performance_report` and `meta_ads_get_insights` in the tools reference
- Updates `SKILL.md` with an Attribution Windows best-practices section including examples for common scenarios (conversion lag comparison, view-through attribution, full window comparison)

Closes #15

## Test plan

- [ ] Review the new Attribution Windows section in `mcp-tools-reference.md`
- [ ] Verify the `attributionWindows` parameter is documented on both `meta_ads_get_performance_report` and `meta_ads_get_insights`
- [ ] Check that the examples in `SKILL.md` are accurate and cover the scenarios requested in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pearmill/hopkin-plugins/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
