### PR TITLE
docs: update Reddit Ads skill with 6 new MCP tools

### DIFF
--- a/hopkin/skills/hopkin-reddit-ads/SKILL.md
+++ b/hopkin/skills/hopkin-reddit-ads/SKILL.md
@@ -99,6 +99,18 @@ No MCC equivalent — all accounts are accessible directly; no `login_customer_i
 - `reddit_ads_get_performance_report` — **Primary analytics tool.** Full-funnel report with breakdowns. Params: `account_id` (required), `date_start` (YYYY-MM-DD, required), `date_end` (YYYY-MM-DD, required), `campaign_ids?`, `ad_group_ids?`, `ad_ids?`, `breakdown?` (max 3 from: campaign, ad_group, ad, community, date, country, region, placement, device_os), `reason`
 - `reddit_ads_get_account_summary` — Account-level summary. Params: `account_id` (required), `date_start` (YYYY-MM-DD, required), `date_end` (YYYY-MM-DD, required), `reason`
 
+### Visualization
+- `reddit_ads_render_chart` — Render interactive data visualization charts as MCP App UI. **Always call this when the user requests a chart, graph, map, or visualization** — never substitute a table or text summary. Fetch data first, then pass it here. Params: `chart` (config with type + data), `reason`. Chart types: `bar`, `scatter`, `timeseries`, `funnel`, `waterfall`, `choropleth`
+
+### Preferences
+- `reddit_ads_store_preference` — Store a persistent preference for a Reddit ad entity (infer from recurring patterns). Params: `entity_type` (ad_account|campaign|ad_set|ad), `entity_id`, `key`, `value`, `reason`
+- `reddit_ads_get_preferences` — Get all stored preferences for an entity. Params: `entity_type`, `entity_id`, `reason`. Preferences also auto-attach to list tool responses as `_stored_preferences`.
+- `reddit_ads_delete_preference` — Delete a stored preference by key. No-op if it doesn't exist. Params: `entity_type`, `entity_id`, `key`, `reason`
+
+### Feedback & Health
+- `reddit_ads_developer_feedback` — Submit feedback about missing tools, improvements, bugs, or workflow gaps in the MCP toolset. Not for user-facing auth/API errors. Params: `feedback_type` (new_tool|improvement|bug|workflow_gap), `title`, `description`, `priority?`, `current_workaround?`, `reason`
+- `reddit_ads_ping` — Health check and connectivity test. Params: `message?`, `reason`
+
 > **Note:** Every tool call requires a `reason` (string) parameter for audit trail.
 
 ## Core Capabilities
@@ -135,8 +147,7 @@ The MCP is **read-only**. When a user requests write operations (pause campaigns
 
 1. Inform them write operations are not yet available via Hopkin
 2. Guide them to perform the action manually in **Reddit Ads Manager**
-
-> There is no `developer_feedback` tool for Reddit Ads yet. No feedback submission is available at this time.
+3. Use `reddit_ads_developer_feedback` with `feedback_type: "workflow_gap"` to report the gap to the development team
 
 ## Report Workflows
 
@@ -265,6 +276,6 @@ See **references/troubleshooting.md** for full guidance.
 
 ---
 
-**Skill Version:** 1.0
+**Skill Version:** 1.1
 **Last Updated:** 2026-03-16
 **Requires:** Hopkin Reddit Ads MCP (https://app.hopkin.ai)

--- a/hopkin/skills/hopkin-reddit-ads/references/mcp-tools-reference.md
+++ b/hopkin/skills/hopkin-reddit-ads/references/mcp-tools-reference.md
@@ -11,6 +11,9 @@ This document provides detailed reference information for the Hopkin Reddit Ads 
 5. [Response Format](#response-format)
 6. [Pagination](#pagination)
 7. [Error Handling](#error-handling)
+8. [Visualization Tools](#visualization-tools)
+9. [Preference Tools](#preference-tools)
+10. [Feedback & Health Tools](#feedback--health-tools)
 
 ---
 
@@ -513,6 +516,174 @@ Hopkin list tools use cursor-based pagination:
 
 ---
 
-**Document Version:** 1.0
+## Visualization Tools
+
+### reddit_ads_render_chart
+Render a data visualization chart as an interactive MCP App UI. **Always call this when the user requests a chart, graph, map, or visualization** — never substitute a table or text summary. Fetch performance data first with reporting tools, then pass the structured data here.
+
+**Parameters:**
+- `reason` (string, required) — Brief explanation of the insight being shown
+- `chart` (object, required) — Chart configuration object containing:
+  - `type` (string, required) — Chart type: `bar`, `scatter`, `timeseries`, `funnel`, `waterfall`, `choropleth`
+  - Additional fields depend on chart type (datasets, axes, labels, etc.)
+
+**Supported Chart Types:**
+- `bar` — Bar chart for comparing values across categories
+- `scatter` — Scatter plot for correlations (e.g., spend vs. conversions)
+- `timeseries` — Time series for trends over date ranges
+- `funnel` — Funnel chart for conversion stages
+- `waterfall` — Waterfall chart for cumulative totals
+- `choropleth` — Geographic map for country/region breakdowns
+
+**Example — Timeseries chart:**
+```json
+{
+  "tool": "reddit_ads_render_chart",
+  "parameters": {
+    "reason": "Showing daily spend trend for the last 30 days",
+    "chart": {
+      "type": "timeseries",
+      "title": "Daily Spend",
+      "data": [
+        { "date": "2026-02-14", "spend": 123.45 },
+        { "date": "2026-02-15", "spend": 98.76 }
+      ]
+    }
+  }
+}
+```
+
+> The chart renderer renders entirely client-side as an MCP App resource. No data is sent externally — all rendering happens in the UI bundle.
+
+---
+
+## Preference Tools
+
+Preferences allow persistent, per-entity storage of recurring settings — metric preferences, alert thresholds, and analysis defaults. Preferences auto-attach to list tool responses as `_stored_preferences`.
+
+### reddit_ads_store_preference
+Store a persistent preference for a Reddit ad entity. Use when you infer a recurring preference from the conversation (e.g., a user always wants ROAS, not CTR).
+
+**Parameters:**
+- `reason` (string, required) — Reason for storing the preference
+- `entity_type` (string, required) — Entity level: `ad_account`, `campaign`, `ad_set` (ad groups), or `ad`
+- `entity_id` (string, required) — The entity's platform ID (e.g., `t2_abc123`)
+- `key` (string, required) — Preference key (e.g., `preferred_conversion_metric`, `budget_alert_threshold`)
+- `value` (any, required) — Value: string, number, boolean, or JSON object
+- `source` (string, optional) — Who set it: `agent` (default), `user`, `system`
+- `note` (string, optional) — Optional context about why this was set
+
+**Example:**
+```json
+{
+  "tool": "reddit_ads_store_preference",
+  "parameters": {
+    "reason": "User always asks for ROAS as the primary metric",
+    "entity_type": "ad_account",
+    "entity_id": "t2_abc123",
+    "key": "preferred_conversion_metric",
+    "value": "ROAS"
+  }
+}
+```
+
+---
+
+### reddit_ads_get_preferences
+Get all stored preferences for a Reddit ad entity.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `entity_type` (string, required) — Entity level: `ad_account`, `campaign`, `ad_set`, or `ad`
+- `entity_id` (string, required) — The entity's platform ID
+
+**Example:**
+```json
+{
+  "tool": "reddit_ads_get_preferences",
+  "parameters": {
+    "reason": "Checking stored preferences before generating report",
+    "entity_type": "ad_account",
+    "entity_id": "t2_abc123"
+  }
+}
+```
+
+---
+
+### reddit_ads_delete_preference
+Delete a stored preference by key. No-op if it doesn't exist.
+
+**Parameters:**
+- `reason` (string, required) — Reason for deleting
+- `entity_type` (string, required) — Entity level: `ad_account`, `campaign`, `ad_set`, or `ad`
+- `entity_id` (string, required) — The entity's platform ID
+- `key` (string, required) — The preference key to delete
+
+**Example:**
+```json
+{
+  "tool": "reddit_ads_delete_preference",
+  "parameters": {
+    "reason": "User no longer wants budget alerts",
+    "entity_type": "campaign",
+    "entity_id": "campaign_456",
+    "key": "budget_alert_threshold"
+  }
+}
+```
+
+---
+
+## Feedback & Health Tools
+
+### reddit_ads_developer_feedback
+Submit feedback about missing tools, improvements, bugs, or workflow gaps in the Reddit Ads MCP toolset. Use when the current tools cannot fulfill a user's request — not for user-facing auth or API errors.
+
+**Parameters:**
+- `reason` (string, required) — What triggered this feedback
+- `feedback_type` (string, required) — Category: `new_tool`, `improvement`, `bug`, `workflow_gap`
+- `title` (string, required) — Concise summary (5–200 characters)
+- `description` (string, required) — What is needed and why (20–2000 characters)
+- `priority` (string, optional) — `low`, `medium` (default), or `high`
+- `current_workaround` (string, optional) — Current workaround, if any
+
+**Example:**
+```json
+{
+  "tool": "reddit_ads_developer_feedback",
+  "parameters": {
+    "reason": "User asked to pause 10 ad groups at once",
+    "feedback_type": "workflow_gap",
+    "title": "Bulk ad group status toggle",
+    "description": "No way to pause or enable multiple ad groups at once. Must do one at a time via Reddit Ads Manager.",
+    "priority": "high",
+    "current_workaround": "Manually pause each ad group in Reddit Ads Manager"
+  }
+}
+```
+
+---
+
+### reddit_ads_ping
+Simple health check and connectivity test for the Reddit Ads MCP server.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the ping
+- `message` (string, optional) — Optional message to echo back
+
+**Example:**
+```json
+{
+  "tool": "reddit_ads_ping",
+  "parameters": {
+    "reason": "Verifying MCP server is reachable before starting session"
+  }
+}
+```
+
+---
+
+**Document Version:** 1.1
 **Last Updated:** 2026-03-16
 **Service:** Hopkin Reddit Ads MCP (https://app.hopkin.ai)


### PR DESCRIPTION
## Summary

Add comprehensive documentation for six new tools released in the Reddit Ads MCP: `reddit_ads_ping`, `reddit_ads_developer_feedback`, preference tools (`store_preference`, `get_preferences`, `delete_preference`), and `reddit_ads_render_chart`.

## Changes

- **SKILL.md:** Added new tool sections (Visualization, Preferences, Feedback & Health) with parameter summaries. Removed outdated note about missing `developer_feedback` tool. Updated write-operations guidance to mention feedback tool for reporting gaps. Bumped version to 1.1.

- **mcp-tools-reference.md:** Expanded with three new reference sections including full parameter documentation, supported chart types, and usage examples for all six tools.

## Test Plan

- Verified all tool parameter documentation matches MCP source implementations
- Checked parameter names, types, and examples against recent MCP release (commit `cdabf5b`)
- Ensured documentation is consistent across skill and reference files