### PR TITLE
Add Mailchimp skill for Hopkin MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Stop switching tabs. Get your ad performance inside Claude.**
 
-Hopkin connects your Meta, Google, LinkedIn, and Reddit Ads accounts directly to Claude — so you can ask questions, pull reports, and surface insights without touching a dashboard.
+Hopkin connects your Meta, Google, LinkedIn, Reddit, TikTok Ads, and Mailchimp accounts directly to Claude — so you can ask questions, pull reports, and surface insights without touching a dashboard.
 
 ## What You Can Do
 
@@ -32,7 +32,7 @@ One install gives you all supported platforms. After installing, Claude will wal
 
 Most ad teams repeat the same workflows every week: morning performance checks, cross-platform comparisons, creative ranking, client reporting. Hopkin turns those into one-line questions.
 
-- **Cross-platform in one conversation** — pull Meta, Google, LinkedIn, and Reddit data side by side
+- **Cross-platform in one conversation** — pull Meta, Google, LinkedIn, Reddit, TikTok, and Mailchimp data side by side
 - **Creative performance** — rank ads by CPA or ROAS with demographic breakdowns
 - **Budget tracking** — spot underspend and overspend across 60+ accounts at once
 - **Trend analysis** — 3, 6, or 12-month views on demand
@@ -47,6 +47,8 @@ Most ad teams repeat the same workflows every week: morning performance checks, 
 | Google Ads | hopkin-google-ads |
 | LinkedIn Ads | hopkin-linkedin-ads |
 | Reddit Ads | hopkin-reddit-ads |
+| TikTok Ads | hopkin-tiktok-ads |
+| Mailchimp | hopkin-mailchimp |
 
 ## Get an Account
 

--- a/hopkin/.claude-plugin/plugin.json
+++ b/hopkin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hopkin",
   "version": "1.4.0",
-  "description": "Analyze ad performance across Google, Meta, LinkedIn, Reddit, and TikTok directly in Claude using Hopkin MCPs",
+  "description": "Analyze ad performance and email marketing across Google, Meta, LinkedIn, Reddit, TikTok, and Mailchimp directly in Claude using Hopkin MCPs",
   "author": {
     "name": "Hopkin"
   },
@@ -13,6 +13,8 @@
     "linkedin-ads",
     "reddit-ads",
     "tiktok-ads",
+    "mailchimp",
+    "email-marketing",
     "advertising",
     "analytics",
     "reporting",

--- a/hopkin/.mcp.json
+++ b/hopkin/.mcp.json
@@ -19,6 +19,10 @@
     "hopkin-tiktok-ads": {
       "type": "http",
       "url": "https://tiktok.mcp.hopkin.ai/mcp"
+    },
+    "hopkin-mailchimp": {
+      "type": "http",
+      "url": "https://mailchimp.mcp.hopkin.ai/mcp"
     }
   }
 }

--- a/hopkin/skills/hopkin-mailchimp/SKILL.md
+++ b/hopkin/skills/hopkin-mailchimp/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: hopkin-mailchimp
+description: Manage and analyze Mailchimp email marketing using the Hopkin Mailchimp MCP. Includes prerequisite checks, authentication flow, campaign reporting, audience insights, subscriber management, automation review, and developer feedback for unsupported write operations.
+---
+
+# Mailchimp Skill
+
+## Introduction
+
+This skill enables Claude to analyze and report on Mailchimp email marketing via the Hopkin Mailchimp MCP. Use this skill when you need to:
+
+- Review campaign performance (opens, clicks, bounces, ecommerce)
+- Analyze audience growth, engagement, and subscriber demographics
+- Explore subscriber details and activity history
+- Audit automations and their email performance
+- Examine segments, tags, and audience organization
+- Review email templates
+
+The skill provides structured workflows for common Mailchimp reporting and analysis tasks, with built-in best practices for data presentation.
+
+## Prerequisites
+
+Before using this skill, verify that the Hopkin Mailchimp MCP is configured and the user is authenticated.
+
+### Check for MCP Availability
+
+To verify the Hopkin Mailchimp MCP is available:
+
+1. Check for `mailchimp_` prefixed tools in your available tools (e.g., `mailchimp_check_auth_status`, `mailchimp_list_accounts`)
+2. If found, the Hopkin Mailchimp MCP is properly configured
+
+### If Hopkin Mailchimp MCP Is Not Installed
+
+If no `mailchimp_` prefixed tools are available:
+
+1. **Inform the user** that the Hopkin Mailchimp MCP is required to use this skill
+2. **Direct them to sign up** at https://app.hopkin.ai
+3. **Provide setup instructions:**
+
+> The Hopkin Mailchimp MCP is not configured. To use this skill:
+>
+> 1. Sign up at **https://app.hopkin.ai**
+> 2. Add the hosted MCP to your Claude configuration:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "hopkin-mailchimp": {
+>       "type": "url",
+>       "url": "https://mailchimp.mcp.hopkin.ai/mcp",
+>       "headers": {
+>         "Authorization": "Bearer YOUR_HOPKIN_TOKEN"
+>       }
+>     }
+>   }
+> }
+> ```
+>
+> 3. Restart Claude after updating configuration
+
+4. **Pause execution** until the user confirms MCP installation is complete
+5. **Re-verify** MCP availability after user confirmation
+
+### Authentication Flow
+
+After confirming the MCP is available, authenticate the user's Mailchimp account:
+
+1. **Check auth status:** Call `mailchimp_check_auth_status` to see if the user is already authenticated
+2. **If not authenticated:** Inform the user that they need to connect their Mailchimp account via https://app.hopkin.ai and follow the OAuth flow there
+
+### Quick Start with Preferences
+
+At the start of any session, call `mailchimp_get_preferences` with `entity_type: "ad_account"` and `entity_id: "global"` to check if the user has stored default settings (e.g., a default account ID or audience). If preferences are found, use them automatically without asking the user. After the user selects or confirms an account/audience, offer to store it as a preference for future sessions using `mailchimp_store_preference`.
+
+### Required Information
+
+Before generating reports, confirm you have:
+
+- **Account ID** — If the user has multiple Mailchimp accounts connected, use `mailchimp_list_accounts` to identify which one to use. If only one account is connected, the `account_id` parameter can be omitted.
+- **Audience ID** — Most operations require an audience (list) ID. Use `mailchimp_list_audiences` to find available audiences.
+
+### Multiple Accounts
+
+Some users connect multiple Mailchimp accounts to Hopkin. When this is the case:
+
+- The `account_id` parameter becomes required on most tools
+- Use `mailchimp_list_accounts` to see all connected accounts with their names and data centers
+- Ask the user which account to use if multiple are available
+
+## Available MCP Tools
+
+For complete tool documentation with all parameters, see **references/mcp-tools-reference.md**.
+
+All 21 tools use the `mailchimp_` prefix. Every tool call requires a `reason` (string) parameter for audit trail.
+
+**Key tools by workflow:**
+- **Account setup:** `mailchimp_list_accounts`, `mailchimp_check_auth_status`
+- **Audiences:** `mailchimp_list_audiences`, `mailchimp_get_audience`
+- **Subscribers:** `mailchimp_list_subscribers`, `mailchimp_get_subscriber` (with `include_activity`)
+- **Campaigns:** `mailchimp_list_campaigns`, `mailchimp_get_campaign` (with `include_content`, `include_send_checklist`)
+- **Automations:** `mailchimp_list_automations`, `mailchimp_get_automation`
+- **Templates:** `mailchimp_list_templates`
+- **Reports:** `mailchimp_get_campaign_report` (primary), `mailchimp_get_audience_insights`, `mailchimp_get_email_activity`
+- **Organization:** `mailchimp_list_segments`, `mailchimp_list_tags`
+- **Preferences:** `mailchimp_store_preference`, `mailchimp_get_preferences`, `mailchimp_delete_preference`
+- **Feedback:** `mailchimp_developer_feedback`
+
+## Core Capabilities
+
+This skill supports six primary report types and a developer feedback workflow for write operations.
+
+### Report Types
+
+1. **Campaign Performance Reports** — Opens, clicks, bounces, forwards, ecommerce revenue, delivery status, and industry benchmarks
+2. **Audience Insights** — Growth history, subscriber activity, email client usage, and geographic distribution
+3. **Email Activity Reports** — Per-recipient engagement for a specific campaign
+4. **Subscriber Analysis** — Individual subscriber details, status, activity history, and merge field data
+5. **Automation Review** — Automation status, email sequence performance, and delivery stats
+6. **Audience Organization** — Segments, tags, and audience structure analysis
+
+### Write Operations (Unsupported — Developer Feedback)
+
+The Hopkin Mailchimp MCP is **read-only**. When a user requests write operations (create campaign, add subscriber, update tags, send campaign, etc.):
+
+1. **Inform the user** that write operations are not yet available via Hopkin
+2. **Submit a feature request** by calling `mailchimp_developer_feedback` with:
+   - `feedback_type: "workflow_gap"`
+   - `title`: Description of the write operation requested
+   - `description`: What the user was trying to do
+   - `current_workaround`: How you worked around the limitation (if applicable)
+   - `priority`: Based on user's urgency
+3. **Provide guidance** on performing the action manually via the Mailchimp web interface
+
+### Proactive Efficiency Feedback
+
+Whenever you complete a task and believe there should have been a faster or more efficient way to get the answer — for example, if you had to make multiple tool calls that could have been a single call, or if a dedicated tool for the workflow would have saved time — call `mailchimp_developer_feedback` with:
+- `feedback_type: "new_tool"` or `"improvement"`
+- `title`: Brief description of the missing capability
+- `description`: Explain what you were trying to accomplish, the steps you had to take, and how a new or improved tool could have made it faster
+- `current_workaround`: The steps you took to work around the limitation
+- `priority`: `"medium"`
+
+### User Feedback to Skill Developers
+
+Users can provide feedback about this skill directly through the Hopkin Mailchimp MCP. If a user wants to suggest improvements, report issues, or request new capabilities, call `mailchimp_developer_feedback` on their behalf with the appropriate `feedback_type` (`new_tool`, `improvement`, `bug`, or `workflow_gap`) and include their feedback in the `description`.
+
+## Report Workflows
+
+### Campaign Performance Report
+
+Analyze the performance of sent email campaigns — opens, clicks, bounces, revenue, and how they compare to industry benchmarks.
+
+**Primary tool:** `mailchimp_get_campaign_report` — provides full performance metrics for a sent campaign
+
+**See detailed workflow:** **references/workflows/campaign-performance.md**
+
+---
+
+### Audience Insights Report
+
+Analyze audience health and growth — subscriber trends, engagement patterns, email client distribution, and geographic breakdown.
+
+**Primary tool:** `mailchimp_get_audience_insights` — fetches growth history, activity, clients, and locations in parallel
+
+**See detailed workflow:** **references/workflows/audience-insights.md**
+
+---
+
+### Subscriber Analysis
+
+Examine individual subscribers — their status, merge fields, activity history, and engagement patterns.
+
+**Primary tools:** `mailchimp_list_subscribers` + `mailchimp_get_subscriber` with `include_activity: true`
+
+**See detailed workflow:** **references/workflows/subscriber-analysis.md**
+
+---
+
+### Automation Review
+
+Review automation sequences — status, email performance, and delivery metrics across the automation workflow.
+
+**Primary tools:** `mailchimp_list_automations` + `mailchimp_get_automation`
+
+**See detailed workflow:** **references/workflows/automation-review.md**
+
+---
+
+## Workflow Process
+
+1. **Account Selection**: If multiple accounts, use `mailchimp_list_accounts` and ask which to use
+2. **Audience Selection**: Most operations require an audience ID — use `mailchimp_list_audiences` and ask user which audience
+3. **Report Type Selection**: Determine which report type matches user intent
+4. **Report Generation**: Use the appropriate Hopkin MCP tool(s)
+5. **Output Formatting**: Present data in clear tables with insights and actionable recommendations
+
+## Best Practices
+
+### Metric Interpretation Guidelines
+
+Choose context appropriate to the analysis:
+- **Campaign Engagement:** Open rate, click rate, click-to-open rate, unsubscribe rate
+- **Deliverability:** Bounce rate (hard vs soft), abuse complaints, delivery rate
+- **Audience Health:** Growth rate, churn rate, list rating, engagement distribution
+- **Revenue (if ecommerce):** Total revenue, revenue per email, average order value
+
+### Industry Benchmarks
+
+Campaign reports include industry comparison stats. Always highlight how the user's metrics compare to their industry average — this provides immediate context for whether performance is good or needs improvement.
+
+### Report Formatting Preferences
+
+- Use tables for multi-row data with consistent columns
+- Use percentage format for rates (e.g., 24.5% open rate)
+- Use currency symbols for monetary values (e.g., $1,234.56)
+- Use thousands separators for large numbers (e.g., 1,234,567)
+- Round appropriately: currency to 2 decimals, percentages to 1-2 decimals, counts to integers
+- Sort meaningfully by the most relevant metric
+- Include report metadata (campaign name, audience name, date sent)
+
+### Error Handling Patterns
+
+When errors occur:
+
+1. **Check authentication** — Run `mailchimp_check_auth_status`; if not authenticated, direct the user to connect their account at https://app.hopkin.ai
+2. **Validate inputs** — Ensure audience_id and campaign_id are correct
+3. **Inspect error messages** — Hopkin errors include specific guidance
+4. **Check campaign status** — Campaign reports require the campaign to be in "sent" status
+5. **Consult troubleshooting guide** — See references/troubleshooting.md
+
+---
+
+## Troubleshooting
+
+For detailed troubleshooting guidance, see **references/troubleshooting.md**.
+
+Common quick fixes:
+
+- **"MCP server not found"** — Verify Hopkin MCP configuration and token
+- **"Not authenticated"** — Run `mailchimp_check_auth_status`; direct user to connect their account at https://app.hopkin.ai
+- **"Campaign not sent"** — Campaign reports only work for campaigns with "sent" status
+- **"Audience not found"** — Verify audience ID with `mailchimp_list_audiences`
+- **"No data available"** — Check that the audience has subscribers or the campaign has been sent
+
+---
+
+## Additional Resources
+
+For more detailed information:
+
+- **references/mcp-tools-reference.md** — Complete Hopkin MCP tool documentation, parameters, and usage examples
+- **references/troubleshooting.md** — Comprehensive error solutions and debugging steps
+- **references/workflows/campaign-performance.md** — Detailed campaign performance report workflow
+- **references/workflows/audience-insights.md** — Detailed audience insights report workflow
+- **references/workflows/subscriber-analysis.md** — Detailed subscriber analysis workflow
+- **references/workflows/automation-review.md** — Detailed automation review workflow
+
+---
+
+**Skill Version:** 1.0
+**Last Updated:** 2026-04-14
+**Requires:** Hopkin Mailchimp MCP (https://app.hopkin.ai)

--- a/hopkin/skills/hopkin-mailchimp/references/mcp-tools-reference.md
+++ b/hopkin/skills/hopkin-mailchimp/references/mcp-tools-reference.md
@@ -1,0 +1,280 @@
+# Mailchimp MCP Tools Reference — Hopkin
+
+Complete parameter reference for all Hopkin Mailchimp MCP tools. For setup and authentication, see **SKILL.md**.
+
+---
+
+## Core Tools
+
+> **Important:** Every Hopkin tool call requires a `reason` (string) parameter for audit trail.
+
+### Authentication Tools
+
+#### mailchimp_check_auth_status
+Check whether the user has authenticated their Mailchimp account. Only call this when another tool returns a permission or authentication error — do not call proactively.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+
+#### mailchimp_ping
+Health check. Verify the MCP server is reachable and returns version/timestamp.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `message` (string, optional) — Optional echo message
+
+---
+
+### Account Tools
+
+#### mailchimp_list_accounts
+List all Mailchimp accounts connected for the authenticated user. Returns account IDs, names, data centers, and login emails.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+
+---
+
+### Audience Tools
+
+#### mailchimp_list_audiences
+List all audiences (lists) in the Mailchimp account with name search and pagination. Returns member count, open rate, click rate, and list rating for each audience.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID. Required when multiple accounts are connected.
+- `search` (string, optional) — Filter audiences by name (case-insensitive substring match)
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor from a previous response
+- `refresh` (boolean, optional, default: false) — Force a fresh fetch bypassing cache
+
+#### mailchimp_get_audience
+Get detailed information about a specific Mailchimp audience (list), including stats, settings, and campaign defaults.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `audience_id` (string, required) — The Mailchimp audience (list) ID
+
+---
+
+### Subscriber Tools
+
+#### mailchimp_list_subscribers
+List subscribers (members) of a Mailchimp audience with status filtering, email search, and pagination.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `audience_id` (string, required) — The Mailchimp audience (list) ID
+- `status` (array of strings, optional) — Filter by status: `subscribed`, `unsubscribed`, `cleaned`, `pending`, `transactional`
+- `search` (string, optional) — Search by email address or name
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor
+
+#### mailchimp_get_subscriber
+Get detailed information about a specific subscriber by email address or MD5 hash. Optionally includes recent activity feed.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `audience_id` (string, required) — The Mailchimp audience (list) ID
+- `email_or_hash` (string, required) — Email address or MD5 subscriber hash
+- `include_activity` (boolean, optional, default: false) — Include recent activity feed
+
+---
+
+### Campaign Tools
+
+#### mailchimp_list_campaigns
+List campaigns in the Mailchimp account with status filtering, title search, and pagination.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `status` (array of strings, optional) — Filter by status: `save`, `paused`, `schedule`, `sending`, `sent`, `canceled`, `canceling`, `archived`
+- `search` (string, optional) — Filter by title (case-insensitive substring match)
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor
+- `refresh` (boolean, optional, default: false) — Force fresh fetch bypassing cache
+
+#### mailchimp_get_campaign
+Get detailed information about a specific Mailchimp campaign. Optionally includes content preview and send checklist.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `campaign_id` (string, required) — The Mailchimp campaign ID
+- `include_content` (boolean, optional, default: false) — Include HTML/text content preview (truncated to 5000 chars)
+- `include_send_checklist` (boolean, optional, default: false) — Include the send checklist
+
+---
+
+### Automation Tools
+
+#### mailchimp_list_automations
+List automations (classic automations / customer journeys) with status filtering, title search, and pagination.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `status` (array of strings, optional) — Filter by status: `save`, `paused`, `sending`
+- `search` (string, optional) — Filter by title (case-insensitive substring match)
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor
+- `refresh` (boolean, optional, default: false) — Force fresh fetch bypassing cache
+
+#### mailchimp_get_automation
+Get detailed information about a specific automation including all associated emails with their delivery stats.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `automation_id` (string, required) — The Mailchimp automation ID
+
+---
+
+### Template Tools
+
+#### mailchimp_list_templates
+List email templates with type filtering, name search, and pagination.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `search` (string, optional) — Filter by name (case-insensitive substring match)
+- `type` (string, optional) — Filter by type: `user`, `base`, `gallery`
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor
+- `refresh` (boolean, optional, default: false) — Force fresh fetch bypassing cache
+
+---
+
+### Reporting Tools
+
+#### mailchimp_get_campaign_report
+Get a detailed performance report for a sent Mailchimp campaign. Includes opens, clicks, bounces, forwards, ecommerce, delivery status, and industry comparison stats.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `campaign_id` (string, required) — The Mailchimp campaign ID. Campaign must be in "sent" status.
+
+**Response includes:**
+- Opens: total opens, unique opens, open rate
+- Clicks: total clicks, unique clicks, click rate, click-to-open rate
+- Bounces: hard bounces, soft bounces, syntax errors
+- Forwards: forward count, forward opens
+- Ecommerce: total orders, total revenue, total spent
+- Delivery: emails sent, delivered, delivery rate
+- Industry stats: open rate, click rate, bounce rate (for comparison)
+- Unsubscribes, abuse reports
+
+#### mailchimp_get_audience_insights
+Get insights for a Mailchimp audience including growth history, activity, email clients, and geographic locations.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `audience_id` (string, required) — The Mailchimp audience/list ID
+- `include_growth_history` (boolean, optional, default: true) — Include growth history data
+- `include_activity` (boolean, optional, default: true) — Include activity data
+- `include_clients` (boolean, optional, default: true) — Include email client data
+- `include_locations` (boolean, optional, default: true) — Include geographic location data
+
+#### mailchimp_get_email_activity
+Get email activity (opens, clicks, bounces) for individual recipients of a sent campaign.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `campaign_id` (string, required) — The Mailchimp campaign ID
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor
+
+---
+
+### Segment Tools
+
+#### mailchimp_list_segments
+List segments for a Mailchimp audience with optional type filtering and pagination.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `audience_id` (string, required) — The Mailchimp audience/list ID
+- `type` (string, optional) — Filter by type: `saved`, `static`, `fuzzy`
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor
+
+---
+
+### Tag Tools
+
+#### mailchimp_list_tags
+List tags for a Mailchimp audience with pagination.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `account_id` (string, optional) — Mailchimp account ID
+- `audience_id` (string, required) — The Mailchimp audience/list ID
+- `limit` (number, optional, default: 20) — Maximum results (1-100)
+- `cursor` (string, optional) — Pagination cursor
+
+---
+
+### Preference Tools
+
+#### mailchimp_store_preference
+Store a persistent preference for a Mailchimp entity.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `entity_type` (string, required) — Entity type: `ad_account`, `campaign`, `ad_set`, `ad`
+- `entity_id` (string, required) — The entity ID
+- `key` (string, required) — Preference key (e.g., `default_audience`, `preferred_metric`)
+- `value` (any, required) — Preference value (string, number, boolean, or JSON object)
+- `source` (string, optional, default: `agent`) — Who set this: `agent`, `user`, `system`
+- `note` (string, optional) — Context about why this preference was set
+
+#### mailchimp_get_preferences
+Get all stored preferences for a Mailchimp entity.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `entity_type` (string, required) — Entity type: `ad_account`, `campaign`, `ad_set`, `ad`
+- `entity_id` (string, required) — The entity ID
+
+#### mailchimp_delete_preference
+Delete a stored preference by key.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `entity_type` (string, required) — Entity type: `ad_account`, `campaign`, `ad_set`, `ad`
+- `entity_id` (string, required) — The entity ID
+- `key` (string, required) — The preference key to delete
+
+---
+
+### Developer Feedback
+
+#### mailchimp_developer_feedback
+Submit feedback about missing tools, improvements, or workflow gaps.
+
+**Parameters:**
+- `reason` (string, required) — Reason for the call
+- `feedback_type` (string, required) — Category: `new_tool`, `improvement`, `bug`, `workflow_gap`
+- `title` (string, required) — Concise title (5-200 chars)
+- `description` (string, required) — What is needed and why (20-2000 chars)
+- `current_workaround` (string, optional) — Current workaround if any
+- `priority` (string, optional, default: `medium`) — Impact: `low`, `medium`, `high`
+
+---
+
+## Pagination
+
+List tools support cursor-based pagination. Pass the `cursor` from a previous response to get the next page. Continue until no cursor is returned.
+
+## Error Handling
+
+See **troubleshooting.md** for detailed error solutions.

--- a/hopkin/skills/hopkin-mailchimp/references/troubleshooting.md
+++ b/hopkin/skills/hopkin-mailchimp/references/troubleshooting.md
@@ -1,0 +1,146 @@
+# Mailchimp Skill - Troubleshooting Guide
+
+This guide provides solutions to common issues encountered when using the Mailchimp skill with the Hopkin Mailchimp MCP.
+
+## Table of Contents
+
+1. [MCP Server Issues](#mcp-server-issues)
+2. [Authentication Problems](#authentication-problems)
+3. [Data Availability Issues](#data-availability-issues)
+4. [API Error Types](#api-error-types)
+5. [Common Mistakes](#common-mistakes)
+
+---
+
+## MCP Server Issues
+
+### MCP Server Not Found
+
+**Symptoms:**
+- No `mailchimp_` prefixed tools available
+- Cannot execute Mailchimp operations
+
+**Diagnosis:**
+1. Check for `mailchimp_` prefixed tools in your available tools
+2. If none are found, the Hopkin Mailchimp MCP is not configured
+
+**Solution:** Follow the setup instructions in the Prerequisites section of SKILL.md. If already configured, verify the token is current and restart Claude.
+
+---
+
+## Authentication Problems
+
+### Not Authenticated with Mailchimp
+
+**Symptoms:**
+- `mailchimp_check_auth_status` returns not authenticated
+- Tools return authentication errors
+- Cannot access account data
+
+**Solution:** Direct the user to https://app.hopkin.ai to complete or redo the OAuth flow. If previously connected, the token may have expired.
+
+### Permission Errors
+
+**Symptoms:**
+- Tools return permission or access denied errors
+- Can authenticate but cannot access specific data
+
+**Solution:** Verify the correct `account_id` is being used (call `mailchimp_list_accounts`). The account may have restricted API permissions, or may need re-authentication via https://app.hopkin.ai.
+
+---
+
+## Data Availability Issues
+
+### No Campaign Report Data
+
+**Symptoms:**
+- `mailchimp_get_campaign_report` returns empty or error
+- Report metrics are all zeros
+
+**Causes & Solutions:**
+
+1. **Campaign not sent:** Reports are only available for campaigns with "sent" status. Check campaign status with `mailchimp_get_campaign`.
+2. **Recently sent:** Reports may take a few minutes to populate after a campaign is sent. Wait and retry.
+3. **Wrong campaign ID:** Verify the campaign ID using `mailchimp_list_campaigns`.
+
+### No Audience Data
+
+**Symptoms:**
+- `mailchimp_list_audiences` returns empty
+- Audience insights show no data
+
+**Causes & Solutions:**
+
+1. **No audiences created:** The Mailchimp account may not have any audiences yet.
+2. **Wrong account:** If multiple accounts connected, verify the correct `account_id`.
+3. **New audience:** A newly created audience may not have enough data for insights.
+
+### Empty Subscriber Lists
+
+**Symptoms:**
+- `mailchimp_list_subscribers` returns no results
+- Search returns no matches
+
+**Causes & Solutions:**
+
+1. **Wrong audience ID:** Verify audience_id with `mailchimp_list_audiences`.
+2. **Status filter too restrictive:** Try without status filter, or check different statuses.
+3. **Search term mismatch:** Search uses the Mailchimp search endpoint — try partial email or name.
+
+---
+
+## API Error Types
+
+### Rate Limiting
+
+**Symptoms:**
+- 429 status code errors
+- "Too many requests" messages
+
+**Solutions:**
+- Wait briefly and retry
+- Reduce the frequency of tool calls
+- Use caching (avoid `refresh: true` unless necessary)
+
+### Invalid Parameters
+
+**Symptoms:**
+- 400 status code errors
+- "Invalid" or "Bad Request" messages
+
+**Solutions:**
+- Verify all required parameters are provided
+- Check that IDs (audience_id, campaign_id, etc.) are correct
+- Ensure status filter values are from the allowed set
+
+### Server Errors
+
+**Symptoms:**
+- 500 status code errors
+- Timeout errors
+
+**Solutions:**
+- Retry the request
+- Check MCP server health with `mailchimp_ping`
+- If persistent, report via `mailchimp_developer_feedback`
+
+---
+
+## Common Mistakes
+
+### Using Wrong IDs
+
+- **Audience ID vs Campaign ID:** These are different identifiers. Use `mailchimp_list_audiences` for audience IDs and `mailchimp_list_campaigns` for campaign IDs.
+- **Account ID:** Only required when multiple accounts are connected. Use `mailchimp_list_accounts` to find the correct one.
+
+### Requesting Reports for Unsent Campaigns
+
+Campaign reports (`mailchimp_get_campaign_report`) only work for campaigns that have been sent. Check the campaign status first with `mailchimp_list_campaigns` filtering by `status: ["sent"]`.
+
+### Not Specifying Account ID with Multiple Accounts
+
+When a user has multiple Mailchimp accounts connected, the `account_id` parameter becomes required. If you get an ambiguous account error, call `mailchimp_list_accounts` and ask the user which account to use.
+
+### Calling Auth Check Proactively
+
+`mailchimp_check_auth_status` should only be called when another tool fails with an auth error. Do not call it proactively at the start of every session.

--- a/hopkin/skills/hopkin-mailchimp/references/workflows/audience-insights.md
+++ b/hopkin/skills/hopkin-mailchimp/references/workflows/audience-insights.md
@@ -1,0 +1,135 @@
+# Audience Insights Report
+
+## Overview
+Analyze audience health and growth — subscriber trends, engagement patterns, email client distribution, and geographic breakdown.
+
+## Primary Tool
+Use `mailchimp_get_audience_insights` for audience-level analytics. This tool fetches multiple data sources in parallel:
+
+- **Growth history:** Subscriber count over time, subscribes/unsubscribes per period
+- **Activity:** Recent audience-level engagement metrics
+- **Email clients:** Distribution of email clients used by subscribers
+- **Locations:** Geographic distribution of subscribers
+
+Each data source degrades gracefully — if one fails, the others still return.
+
+## Required Parameters
+- **audience_id**: The Mailchimp audience/list ID
+
+## Step-by-Step Workflow
+
+### Step 1: Identify the Audience
+
+If the user hasn't specified an audience:
+
+```json
+{
+  "tool": "mailchimp_list_audiences",
+  "parameters": {
+    "reason": "Finding audiences to analyze"
+  }
+}
+```
+
+Present the list with member counts and ratings. Ask the user which audience to analyze.
+
+### Step 2: Get Audience Details
+
+For baseline stats and settings:
+
+```json
+{
+  "tool": "mailchimp_get_audience",
+  "parameters": {
+    "reason": "Getting audience baseline stats",
+    "audience_id": "abc123"
+  }
+}
+```
+
+### Step 3: Get Audience Insights
+
+```json
+{
+  "tool": "mailchimp_get_audience_insights",
+  "parameters": {
+    "reason": "Analyzing audience health and growth",
+    "audience_id": "abc123",
+    "include_growth_history": true,
+    "include_activity": true,
+    "include_clients": true,
+    "include_locations": true
+  }
+}
+```
+
+### Step 4: Segment Analysis (Optional)
+
+To understand audience structure:
+
+```json
+{
+  "tool": "mailchimp_list_segments",
+  "parameters": {
+    "reason": "Reviewing audience segments",
+    "audience_id": "abc123"
+  }
+}
+```
+
+### Step 5: Tag Overview (Optional)
+
+To see how subscribers are organized:
+
+```json
+{
+  "tool": "mailchimp_list_tags",
+  "parameters": {
+    "reason": "Reviewing audience tags",
+    "audience_id": "abc123"
+  }
+}
+```
+
+## Output Format
+
+### Audience Overview
+
+| Metric | Value |
+|--------|-------|
+| Audience Name | {name} |
+| Total Members | {count} |
+| Subscribed | {count} |
+| Unsubscribed | {count} |
+| Cleaned | {count} |
+| Open Rate | {rate}% |
+| Click Rate | {rate}% |
+| List Rating | {rating}/5 |
+
+### Growth Trends
+
+Present growth history as a trend summary:
+- Net growth over the period
+- Average subscribes/unsubscribes per month
+- Any notable spikes or drops
+
+### Email Client Distribution
+
+| Client | Percentage |
+|--------|-----------|
+| Gmail | {pct}% |
+| Apple Mail | {pct}% |
+| Outlook | {pct}% |
+| Other | {pct}% |
+
+### Geographic Distribution
+
+Top locations by subscriber count.
+
+## Analysis Guidelines
+
+1. **Assess list health:** A healthy list has low bounce rates, consistent growth, and high engagement
+2. **Flag cleaning needs:** High cleaned/unsubscribed counts suggest list hygiene issues
+3. **Email client insights:** Client distribution affects rendering — if most subscribers use mobile clients, email design should be mobile-first
+4. **Geographic insights:** Location data informs send time optimization and content localization
+5. **Growth trajectory:** Is the list growing, shrinking, or stagnant? What's driving the trend?

--- a/hopkin/skills/hopkin-mailchimp/references/workflows/automation-review.md
+++ b/hopkin/skills/hopkin-mailchimp/references/workflows/automation-review.md
@@ -1,0 +1,89 @@
+# Automation Review
+
+## Overview
+Review automation sequences — status, email performance, and delivery metrics across automation workflows.
+
+## Primary Tools
+- `mailchimp_list_automations` — List automations with status filtering
+- `mailchimp_get_automation` — Get automation details with per-email delivery stats
+
+## Step-by-Step Workflow
+
+### Step 1: List Automations
+
+**All active automations:**
+```json
+{
+  "tool": "mailchimp_list_automations",
+  "parameters": {
+    "reason": "Listing active automations",
+    "status": ["sending"]
+  }
+}
+```
+
+**All automations:**
+```json
+{
+  "tool": "mailchimp_list_automations",
+  "parameters": {
+    "reason": "Listing all automations for review"
+  }
+}
+```
+
+### Step 2: Get Automation Details
+
+```json
+{
+  "tool": "mailchimp_get_automation",
+  "parameters": {
+    "reason": "Reviewing automation performance",
+    "automation_id": "abc123def4"
+  }
+}
+```
+
+This returns the automation details plus all associated emails with their delivery stats (opens, clicks, bounces per email in the sequence).
+
+## Output Format
+
+### Automation Summary
+
+| Field | Value |
+|-------|-------|
+| Name | {automation name} |
+| Status | {sending/paused/save} |
+| Audience | {audience name} |
+| Emails in Sequence | {count} |
+| Created | {date} |
+
+### Email Sequence Performance
+
+| # | Subject | Sends | Opens | Open Rate | Clicks | Click Rate |
+|---|---------|-------|-------|-----------|--------|------------|
+| 1 | {subject} | {n} | {n} | {rate}% | {n} | {rate}% |
+| 2 | {subject} | {n} | {n} | {rate}% | {n} | {rate}% |
+| 3 | {subject} | {n} | {n} | {rate}% | {n} | {rate}% |
+
+## Analysis Guidelines
+
+1. **Drop-off analysis:** Compare engagement across emails in the sequence — a significant drop suggests optimization opportunity
+2. **Status review:** Paused automations may need attention. Draft/save automations haven't been activated.
+3. **Per-email performance:** Identify which emails in the sequence perform best/worst
+4. **Audience alignment:** Verify the automation targets the intended audience
+5. **Suggest improvements:** For underperforming emails, suggest subject line or content changes
+
+## Multi-Automation Comparison
+
+When reviewing all automations:
+
+1. List all automations with `mailchimp_list_automations`
+2. Call `mailchimp_get_automation` for each active automation
+3. Present a summary table comparing key metrics across automations
+
+| Automation | Status | Emails | Total Sends | Avg Open Rate |
+|-----------|--------|--------|-------------|---------------|
+| Welcome Series | Sending | 3 | 5,432 | 42.1% |
+| Onboarding | Sending | 5 | 2,187 | 35.8% |
+| Re-engagement | Paused | 2 | 876 | 18.4% |

--- a/hopkin/skills/hopkin-mailchimp/references/workflows/campaign-performance.md
+++ b/hopkin/skills/hopkin-mailchimp/references/workflows/campaign-performance.md
@@ -1,0 +1,141 @@
+# Campaign Performance Report
+
+## Overview
+Analyze the performance of sent Mailchimp email campaigns — opens, clicks, bounces, ecommerce revenue, and industry benchmarks.
+
+## Primary Tool
+Use `mailchimp_get_campaign_report` for campaign performance reports. This tool returns comprehensive metrics in a single call:
+
+- **Opens:** total opens, unique opens, open rate
+- **Clicks:** total clicks, unique clicks, click rate, click-to-open rate
+- **Bounces:** hard bounces, soft bounces, syntax errors
+- **Forwards:** forward count, forward opens
+- **Ecommerce:** total orders, total revenue, total spent
+- **Delivery:** emails sent, delivered, delivery rate
+- **Industry stats:** open rate, click rate, bounce rate (for comparison)
+- **Unsubscribes and abuse reports**
+
+## Required Parameters
+- **campaign_id**: The Mailchimp campaign ID (campaign must be in "sent" status)
+
+## Step-by-Step Workflow
+
+### Step 1: Identify the Campaign
+
+If the user hasn't specified a campaign:
+
+```json
+{
+  "tool": "mailchimp_list_campaigns",
+  "parameters": {
+    "reason": "Finding sent campaigns to report on",
+    "status": ["sent"],
+    "limit": 10
+  }
+}
+```
+
+Present the list and ask the user which campaign to analyze. If they mention a campaign by name, use the `search` parameter.
+
+### Step 2: Get Campaign Details (Optional)
+
+For additional context about the campaign:
+
+```json
+{
+  "tool": "mailchimp_get_campaign",
+  "parameters": {
+    "reason": "Getting campaign details for context",
+    "campaign_id": "abc123def4",
+    "include_content": false,
+    "include_send_checklist": false
+  }
+}
+```
+
+### Step 3: Generate the Report
+
+```json
+{
+  "tool": "mailchimp_get_campaign_report",
+  "parameters": {
+    "reason": "Generating campaign performance report",
+    "campaign_id": "abc123def4"
+  }
+}
+```
+
+### Step 4: Analyze Per-Recipient Activity (Optional)
+
+For deeper engagement analysis:
+
+```json
+{
+  "tool": "mailchimp_get_email_activity",
+  "parameters": {
+    "reason": "Analyzing per-recipient engagement",
+    "campaign_id": "abc123def4",
+    "limit": 50
+  }
+}
+```
+
+## Output Format
+
+Present results in a structured format:
+
+### Campaign Summary Table
+
+| Metric | Value |
+|--------|-------|
+| Campaign | {campaign name} |
+| Sent | {send date} |
+| Audience | {audience name} |
+| Emails Sent | {count} |
+
+### Engagement Metrics
+
+| Metric | Value | Industry Avg |
+|--------|-------|-------------|
+| Open Rate | {rate}% | {industry}% |
+| Click Rate | {rate}% | {industry}% |
+| Click-to-Open Rate | {rate}% | — |
+| Bounce Rate | {rate}% | {industry}% |
+| Unsubscribe Rate | {rate}% | — |
+
+### Deliverability
+
+| Metric | Count |
+|--------|-------|
+| Delivered | {count} |
+| Hard Bounces | {count} |
+| Soft Bounces | {count} |
+| Abuse Reports | {count} |
+
+### Ecommerce (if applicable)
+
+| Metric | Value |
+|--------|-------|
+| Total Orders | {count} |
+| Total Revenue | ${amount} |
+| Revenue per Email | ${amount} |
+
+## Analysis Guidelines
+
+1. **Compare to industry:** Always highlight how metrics compare to industry averages
+2. **Flag concerns:** Call out high bounce rates (>2%), high unsubscribe rates (>0.5%), or abuse complaints
+3. **Highlight wins:** Note when open/click rates exceed industry averages
+4. **Suggest improvements:** Based on metrics, suggest actionable next steps (e.g., subject line testing for low open rates, CTA optimization for low click rates)
+
+## Multi-Campaign Comparison
+
+To compare multiple campaigns:
+
+1. Use `mailchimp_list_campaigns` with `status: ["sent"]` to get recent campaigns
+2. Call `mailchimp_get_campaign_report` for each campaign
+3. Present a comparison table with key metrics side by side
+
+| Campaign | Open Rate | Click Rate | Unsubs | Revenue |
+|----------|-----------|------------|--------|---------|
+| Campaign A | 24.5% | 3.2% | 5 | $1,234 |
+| Campaign B | 21.8% | 2.8% | 3 | $987 |

--- a/hopkin/skills/hopkin-mailchimp/references/workflows/subscriber-analysis.md
+++ b/hopkin/skills/hopkin-mailchimp/references/workflows/subscriber-analysis.md
@@ -1,0 +1,102 @@
+# Subscriber Analysis
+
+## Overview
+Examine individual subscribers — their status, merge fields, activity history, and engagement patterns.
+
+## Primary Tools
+- `mailchimp_list_subscribers` — Find subscribers by status or search
+- `mailchimp_get_subscriber` — Get full details with optional activity feed
+
+## Step-by-Step Workflow
+
+### Step 1: Identify the Audience
+
+```json
+{
+  "tool": "mailchimp_list_audiences",
+  "parameters": {
+    "reason": "Finding audience for subscriber lookup"
+  }
+}
+```
+
+### Step 2: Find Subscribers
+
+**By email or name:**
+```json
+{
+  "tool": "mailchimp_list_subscribers",
+  "parameters": {
+    "reason": "Searching for specific subscriber",
+    "audience_id": "abc123",
+    "search": "user@example.com"
+  }
+}
+```
+
+**By status:**
+```json
+{
+  "tool": "mailchimp_list_subscribers",
+  "parameters": {
+    "reason": "Listing unsubscribed members",
+    "audience_id": "abc123",
+    "status": ["unsubscribed"],
+    "limit": 50
+  }
+}
+```
+
+### Step 3: Get Subscriber Details
+
+```json
+{
+  "tool": "mailchimp_get_subscriber",
+  "parameters": {
+    "reason": "Getting full subscriber profile",
+    "audience_id": "abc123",
+    "email_or_hash": "user@example.com",
+    "include_activity": true
+  }
+}
+```
+
+## Output Format
+
+### Subscriber Profile
+
+| Field | Value |
+|-------|-------|
+| Email | {email} |
+| Status | {status} |
+| Rating | {rating}/5 |
+| Signup Date | {date} |
+| Last Changed | {date} |
+| Language | {language} |
+| Location | {city, country} |
+
+### Merge Fields
+
+Display any custom merge fields (first name, last name, company, etc.) stored for the subscriber.
+
+### Recent Activity
+
+| Date | Action | Details |
+|------|--------|---------|
+| {date} | Opened | {campaign name} |
+| {date} | Clicked | {URL in campaign} |
+
+## Analysis Guidelines
+
+1. **Engagement rating:** Mailchimp rates subscribers 1-5 based on engagement. Low ratings suggest inactive subscribers.
+2. **Activity patterns:** Look for open/click trends — active openers vs never-engagers.
+3. **Status transitions:** Note if a subscriber has been cleaned or unsubscribed, and when.
+4. **Segment membership:** Cross-reference with segments to understand subscriber categorization.
+
+## Bulk Analysis
+
+For audience-wide subscriber analysis:
+
+1. Use `mailchimp_list_subscribers` with different status filters to understand distribution
+2. Compare counts across statuses: subscribed, unsubscribed, cleaned, pending
+3. Use `mailchimp_get_audience_insights` for aggregate engagement metrics rather than checking individual subscribers


### PR DESCRIPTION
## Summary
- Adds new `hopkin-mailchimp` skill covering all 21 Mailchimp MCP tools (domain: `mailchimp.mcp.hopkin.ai`)
- Includes SKILL.md, tools reference, troubleshooting guide, and 4 workflow docs (campaign performance, audience insights, subscriber analysis, automation review)
- Token-efficient structure (~7k tokens total, ~336 tokens/tool) — avoids duplication across files by using single source of truth for setup/auth and pointing to the reference doc for full parameters

## Test plan
- [ ] Verify skill loads correctly in Claude Code
- [ ] Test MCP connectivity with `mailchimp_ping`
- [ ] Run through campaign report workflow end-to-end
- [ ] Confirm tool parameter docs match actual MCP server schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)