### PR TITLE
Add per-skill zip uploads and claude-plugin.zip workflow

### DIFF
--- a/.github/workflows/detect-and-release-skills.yml
+++ b/.github/workflows/detect-and-release-skills.yml
@@ -148,12 +148,12 @@ jobs:
 
           find "$TEMP_DIR/hopkin" -name ".DS_Store" -delete
 
+          # Create combined zip
           cd "$TEMP_DIR"
           zip -r -q "hopkin.zip" "hopkin"
           cd - > /dev/null
 
           mv "$TEMP_DIR/hopkin.zip" "releases/hopkin-v${VERSION}.zip"
-          rm -rf "$TEMP_DIR"
 
           PACKAGE_FILE="releases/hopkin-v${VERSION}.zip"
           if [ ! -f "$PACKAGE_FILE" ]; then
@@ -163,6 +163,31 @@ jobs:
 
           echo "Package created: $PACKAGE_FILE"
           ls -lh "$PACKAGE_FILE"
+
+          # Create per-skill zips
+          for SKILL_DIR in hopkin/skills/hopkin-*; do
+            if [ -d "$SKILL_DIR" ]; then
+              SKILL_FULL_NAME=$(basename "$SKILL_DIR")
+              # Strip "hopkin-" prefix to get the skill name (e.g. "google-ads", "mailchimp")
+              SKILL_NAME="${SKILL_FULL_NAME#hopkin-}"
+
+              SKILL_TEMP=$(mktemp -d)
+              cp -R "$SKILL_DIR" "$SKILL_TEMP/$SKILL_FULL_NAME"
+              find "$SKILL_TEMP" -name ".DS_Store" -delete
+
+              cd "$SKILL_TEMP"
+              zip -r -q "${SKILL_NAME}.zip" "$SKILL_FULL_NAME"
+              cd - > /dev/null
+
+              mv "$SKILL_TEMP/${SKILL_NAME}.zip" "releases/${SKILL_NAME}-v${VERSION}.zip"
+              rm -rf "$SKILL_TEMP"
+
+              echo "Skill package created: releases/${SKILL_NAME}-v${VERSION}.zip"
+              ls -lh "releases/${SKILL_NAME}-v${VERSION}.zip"
+            fi
+          done
+
+          rm -rf "$TEMP_DIR"
 
       - name: Setup Node.js
         if: steps.check_release.outputs.exists == 'false'
@@ -184,12 +209,14 @@ jobs:
           node -e "
             const { put } = require('@vercel/blob');
             const fs = require('fs');
+            const path = require('path');
 
             async function upload() {
               const version = process.env.VERSION;
+
+              // Upload combined plugin zip
               const file = fs.readFileSync(process.env.PACKAGE_FILE);
 
-              // Upload as latest
               const latest = await put('skills/hopkin/latest.zip', file, {
                 access: 'public',
                 addRandomSuffix: false,
@@ -197,13 +224,38 @@ jobs:
               });
               console.log('Uploaded latest:', latest.url);
 
-              // Upload versioned copy
               const versioned = await put('skills/hopkin/v' + version + '.zip', file, {
                 access: 'public',
                 addRandomSuffix: false,
                 allowOverwrite: true,
               });
               console.log('Uploaded versioned:', versioned.url);
+
+              // Upload per-skill zips
+              const releaseFiles = fs.readdirSync('releases');
+              for (const fileName of releaseFiles) {
+                // Skip the combined plugin zip (already uploaded above)
+                if (fileName.startsWith('hopkin-v')) continue;
+
+                // Extract skill name from filename like 'google-ads-v1.5.0.zip'
+                const skillName = fileName.replace('-v' + version + '.zip', '');
+
+                const skillFile = fs.readFileSync(path.join('releases', fileName));
+
+                const skillLatest = await put('skills/' + skillName + '/latest.zip', skillFile, {
+                  access: 'public',
+                  addRandomSuffix: false,
+                  allowOverwrite: true,
+                });
+                console.log('Uploaded ' + skillName + ' latest:', skillLatest.url);
+
+                const skillVersioned = await put('skills/' + skillName + '/v' + version + '.zip', skillFile, {
+                  access: 'public',
+                  addRandomSuffix: false,
+                  allowOverwrite: true,
+                });
+                console.log('Uploaded ' + skillName + ' versioned:', skillVersioned.url);
+              }
             }
 
             upload().catch(err => { console.error(err); process.exit(1); });

--- a/.github/workflows/publish-claude-plugin.yml
+++ b/.github/workflows/publish-claude-plugin.yml
@@ -1,0 +1,65 @@
+name: Publish Claude Plugin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'hopkin/**'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Package plugin
+        run: |
+          set -e
+
+          TEMP_DIR=$(mktemp -d)
+          cp -R "hopkin" "$TEMP_DIR/hopkin"
+          find "$TEMP_DIR/hopkin" -name ".DS_Store" -delete
+
+          cd "$TEMP_DIR"
+          zip -r -q "claude-plugin.zip" "hopkin"
+          cd - > /dev/null
+
+          mv "$TEMP_DIR/claude-plugin.zip" "claude-plugin.zip"
+          rm -rf "$TEMP_DIR"
+
+          echo "Package created: claude-plugin.zip"
+          ls -lh "claude-plugin.zip"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Upload to Vercel Blob
+        env:
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+        run: |
+          set -e
+
+          npm install @vercel/blob
+
+          node -e "
+            const { put } = require('@vercel/blob');
+            const fs = require('fs');
+
+            async function upload() {
+              const file = fs.readFileSync('claude-plugin.zip');
+
+              const result = await put('plugins/claude-plugin.zip', file, {
+                access: 'public',
+                addRandomSuffix: false,
+                allowOverwrite: true,
+              });
+              console.log('Uploaded claude-plugin.zip:', result.url);
+            }
+
+            upload().catch(err => { console.error(err); process.exit(1); });
+          "


### PR DESCRIPTION
## Summary
- **Per-skill zips**: The release workflow now packages and uploads individual skill zips (google-ads, meta-ads, linkedin-ads, reddit-ads, tiktok-ads, mailchimp) to Vercel Blob alongside the combined plugin zip
- **Claude plugin workflow**: New `publish-claude-plugin.yml` workflow zips the entire `hopkin` folder and uploads it as `plugins/claude-plugin.zip` on every push to main
- Fixes missing downloads for tiktok-ads and mailchimp (`app.hopkin.ai/downloads/tiktok-ads-latest.zip` etc.)

## Test plan
- [ ] Merge and verify the release workflow runs successfully
- [ ] Confirm all skill zips are uploaded to Vercel Blob (`skills/{name}/latest.zip`)
- [ ] Confirm `claude-plugin.zip` is uploaded to `plugins/claude-plugin.zip`
- [ ] Verify download URLs work: `app.hopkin.ai/downloads/tiktok-ads-latest.zip`, `app.hopkin.ai/downloads/mailchimp-latest.zip`, `app.hopkin.ai/downloads/claude-plugin.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)