### PR TITLE
Add Google Search Console skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "hopkin",
       "source": "./hopkin",
-      "description": "Analyze ad performance across Google, Meta, LinkedIn, Reddit, and TikTok directly in Claude using Hopkin MCPs",
+      "description": "Analyze ad performance, email marketing, and search console data across Google, Meta, LinkedIn, Reddit, TikTok, Mailchimp, and Google Search Console directly in Claude using Hopkin MCPs",
       "version": "1.6.0"
     }
   ]

--- a/hopkin/.claude-plugin/plugin.json
+++ b/hopkin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hopkin",
   "version": "1.6.0",
-  "description": "Analyze ad performance and email marketing across Google, Meta, LinkedIn, Reddit, TikTok, and Mailchimp directly in Claude using Hopkin MCPs",
+  "description": "Analyze ad performance, email marketing, and search console data across Google, Meta, LinkedIn, Reddit, TikTok, Mailchimp, and Google Search Console directly in Claude using Hopkin MCPs",
   "author": {
     "name": "Hopkin"
   },
@@ -14,6 +14,8 @@
     "reddit-ads",
     "tiktok-ads",
     "mailchimp",
+    "google-search-console",
+    "seo",
     "email-marketing",
     "advertising",
     "analytics",

--- a/hopkin/.mcp.json
+++ b/hopkin/.mcp.json
@@ -23,6 +23,10 @@
     "hopkin-mailchimp": {
       "type": "http",
       "url": "https://mailchimp.mcp.hopkin.ai/mcp"
+    },
+    "hopkin-google-search-console": {
+      "type": "http",
+      "url": "https://gcs.mcp.hopkin.ai/mcp"
     }
   }
 }

--- a/hopkin/skills/hopkin-google-search-console/SKILL.md
+++ b/hopkin/skills/hopkin-google-search-console/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: hopkin-google-search-console
+description: Analyze Google Search Console data using the Hopkin Google Search Console MCP. Includes search analytics, top queries, performance comparisons, URL inspection, site management, and SEO opportunity identification.
+---
+
+# Google Search Console Skill
+
+## Introduction
+
+This skill enables Claude to analyze Google Search Console data via the Hopkin Google Search Console MCP. Use this skill when you need to:
+
+- Query search analytics (clicks, impressions, CTR, position) across queries, pages, devices, and countries
+- Identify top-performing and high-opportunity search queries
+- Compare search performance across time periods (period-over-period)
+- Get a complete performance overview with trends
+- Inspect URL indexing and crawl status
+- Review sitemaps and site properties
+
+The skill provides structured workflows for common SEO analysis tasks, with built-in best practices for data interpretation and presentation.
+
+## Prerequisites
+
+Before using this skill, verify that the Hopkin Google Search Console MCP is configured and the user is authenticated.
+
+### Check for MCP Availability
+
+To verify the Hopkin Google Search Console MCP is available:
+
+1. Check for `google_search_console_` prefixed tools in your available tools (e.g., `google_search_console_check_auth_status`, `google_search_console_list_sites`)
+2. If found, the Hopkin Google Search Console MCP is properly configured
+
+### If Hopkin Google Search Console MCP Is Not Installed
+
+If no `google_search_console_` prefixed tools are available:
+
+1. **Inform the user** that the Hopkin Google Search Console MCP is required to use this skill
+2. **Direct them to sign up** at https://app.hopkin.ai
+3. **Provide setup instructions:**
+
+> The Hopkin Google Search Console MCP is not configured. To use this skill:
+>
+> 1. Sign up at **https://app.hopkin.ai**
+> 2. Add the hosted MCP to your Claude configuration:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "hopkin-google-search-console": {
+>       "type": "url",
+>       "url": "https://gcs.mcp.hopkin.ai/mcp",
+>       "headers": {
+>         "Authorization": "Bearer YOUR_HOPKIN_TOKEN"
+>       }
+>     }
+>   }
+> }
+> ```
+>
+> 3. Restart Claude after updating configuration
+
+4. **Pause execution** until the user confirms MCP installation is complete
+5. **Re-verify** MCP availability after user confirmation
+
+### Authentication Flow
+
+After confirming the MCP is available, authenticate the user's Google Search Console account:
+
+1. **Check auth status:** Call `google_search_console_check_auth_status` to see if the user is already authenticated
+2. **If not authenticated:** Inform the user that they need to connect their Google Search Console account via https://app.hopkin.ai and follow the OAuth flow there
+
+### Quick Start with Preferences
+
+At the start of any session, call `google_search_console_get_preferences` with `entity_type: "site"` and `entity_id: "global"` to check if the user has a stored default site URL. If preferences are found, use them automatically without asking the user. After the user selects or confirms a site, offer to store it as a preference for future sessions using `google_search_console_store_preference`.
+
+### Required Information
+
+Before generating reports, confirm you have:
+
+- **Site URL** — The Search Console property to query (e.g., `https://example.com/` or `sc-domain:example.com`). Use `google_search_console_list_sites` to find available properties.
+- **Date Range** — Time period for data. Note that Search Console data has a 2-3 day lag; recent dates may be incomplete.
+
+## Available MCP Tools
+
+For complete tool documentation with all parameters, see **references/mcp-tools-reference.md**.
+
+All 12 tools use the `google_search_console_` prefix.
+
+### Authentication
+- `google_search_console_ping` — Health check; verify the MCP server is reachable
+- `google_search_console_check_auth_status` — Check if user is authenticated; only call when another tool returns an auth error
+
+### Sites
+- `google_search_console_list_sites` — List all Search Console properties the user has access to, with permission levels
+
+### Sitemaps
+- `google_search_console_list_sitemaps` — List sitemaps submitted to a Search Console property with status and error counts
+
+### Analytics
+- `google_search_console_get_search_analytics` — **Flexible query tool.** Full control over dimensions, filters, date ranges, search types, and aggregation. Use for custom analytics queries.
+- `google_search_console_get_top_queries` — **Recommended for query analysis.** Returns top queries with auto-identified high-opportunity queries (position 4-20, impressions >100, CTR <5%).
+- `google_search_console_compare_performance` — **Period-over-period comparison.** Compares current vs previous period with delta calculations and trend classification.
+- `google_search_console_get_performance_overview` — **Complete overview.** Returns overall metrics, top queries, top pages, and daily trend in a single call (4 parallel API calls).
+
+### URL Inspection
+- `google_search_console_inspect_url` — Get detailed indexing, crawl, and canonical status for a specific URL. Quota: 2000 calls/day per property.
+
+### Preferences
+- `google_search_console_store_preference` — Store a persistent preference or observation for a Search Console entity
+- `google_search_console_get_preferences` — Retrieve all stored preferences for an entity
+- `google_search_console_delete_preference` — Delete a specific stored preference by key
+
+### Feedback
+- `google_search_console_developer_feedback` — Submit feature requests and workflow gap reports
+
+## Core Capabilities
+
+This skill supports five primary analysis types and a developer feedback workflow.
+
+### Analysis Types
+
+1. **Search Analytics Reports** — Flexible queries across any combination of dimensions (query, page, device, country, date, searchAppearance) with filtering and pagination
+2. **Top Queries Analysis** — Identify best-performing queries and auto-detect high-opportunity queries ripe for optimization
+3. **Performance Comparison** — Period-over-period analysis with trend detection (improving, stable, declining)
+4. **Performance Overview** — Comprehensive site health dashboard with top queries, top pages, and daily trends
+5. **URL Inspection** — Deep-dive into indexing status, crawl details, canonical URLs, and robots.txt state for individual URLs
+
+### Data Visualization
+
+Search Console data lends itself well to tables and trend analysis. Present data with:
+- Sorted tables for top queries and pages
+- Trend indicators for period-over-period changes
+- Highlight high-opportunity queries prominently
+- Use sparkline-style descriptions for daily trends when appropriate
+
+### Write Operations (Unsupported — Developer Feedback)
+
+The Hopkin Google Search Console MCP is **read-only**. When a user requests write operations (submit URL for indexing, add sitemap, request removal, etc.):
+
+1. **Inform the user** that write operations are not yet available via Hopkin
+2. **Submit a feature request** by calling `google_search_console_developer_feedback` with:
+   - `feedback_type: "workflow_gap"`
+   - `title`: Description of the write operation requested
+   - `description`: What the user was trying to do
+   - `current_workaround`: How you worked around the limitation (if applicable)
+   - `priority`: Based on user's urgency
+3. **Provide guidance** on performing the action manually via Google Search Console
+
+### Proactive Efficiency Feedback
+
+Whenever you complete a task and believe there should have been a faster or more efficient way to get the answer — for example, if you had to make multiple tool calls that could have been a single call, or if a dedicated tool for the workflow would have saved time — call `google_search_console_developer_feedback` with:
+- `feedback_type: "new_tool"` or `"improvement"`
+- `title`: Brief description of the missing capability
+- `description`: Explain what you were trying to accomplish, the steps you had to take, and how a new or improved tool could have made it faster
+- `current_workaround`: The steps you took to work around the limitation
+- `priority`: `"medium"`
+
+### User Feedback to Skill Developers
+
+Users can provide feedback about this skill directly through the Hopkin Google Search Console MCP. If a user wants to suggest improvements, report issues, or request new capabilities, call `google_search_console_developer_feedback` on their behalf with the appropriate `feedback_type` (`new_tool`, `improvement`, `bug`, or `workflow_gap`) and include their feedback in the `description`.
+
+## Report Workflows
+
+### Search Analytics Report
+
+Query search analytics data with flexible dimensions and filters. Analyze performance by query, page, device, country, date, or search appearance.
+
+**Primary tool:** `google_search_console_get_search_analytics` — full control over dimensions, filters, search type, aggregation, and pagination
+
+**See detailed workflow:** **references/workflows/search-analytics.md**
+
+---
+
+### Top Queries Report
+
+Identify the best-performing search queries and discover high-opportunity queries that could benefit from SEO optimization.
+
+**Primary tool:** `google_search_console_get_top_queries` — returns ranked queries with automatic high-opportunity detection
+
+**See detailed workflow:** **references/workflows/top-queries.md**
+
+---
+
+### Performance Comparison Report
+
+Compare search performance across two adjacent time periods to identify trends, improvements, and regressions.
+
+**Primary tool:** `google_search_console_compare_performance` — period-over-period analysis with delta calculations
+
+**See detailed workflow:** **references/workflows/performance-comparison.md**
+
+---
+
+### URL Inspection Report
+
+Get detailed indexing, crawl, and canonical status for specific URLs. Diagnose why pages aren't appearing in search results.
+
+**Primary tool:** `google_search_console_inspect_url` — returns verdict, coverage state, crawl details, and canonical information
+
+**See detailed workflow:** **references/workflows/url-inspection.md**
+
+---
+
+## Workflow Process
+
+1. **Site Selection**: If no site URL provided, use `google_search_console_list_sites` first and ask the user which property to analyze
+2. **Date Range**: Default to last 28 days if not specified. Account for the 2-3 day data lag.
+3. **Analysis Type Selection**: Determine which analysis matches user intent
+4. **Data Retrieval**: Use the appropriate Hopkin MCP tool
+5. **Output Formatting**: Present data in clear tables with insights and actionable SEO recommendations
+
+## Best Practices
+
+### Data Freshness
+
+- **Search Console data has a 2-3 day lag.** The most recent 3 days may be incomplete.
+- Check the `firstIncompleteDate` field in analytics responses to know which dates have partial data.
+- For accurate trend analysis, exclude incomplete dates or caveat them clearly.
+- The `compare_performance` tool automatically applies a 3-day offset by default.
+
+### Date Range Considerations
+
+- **Short-term (1-7 days):** Quick pulse checks, recent content performance
+- **Medium-term (7-28 days):** Standard for SEO performance evaluation
+- **Long-term (28-90 days):** Seasonal patterns, algorithm update impact, strategic analysis
+- Search Console retains up to 16 months of data, but the API limits queries to 90 days per request
+
+### Dimension Combinations
+
+- `searchAppearance` dimension **cannot** be combined with `query`, `page`, `device`, or `country` — it can only be combined with `date`
+- Common useful combinations: `[query, page]`, `[query, device]`, `[page, country]`, `[query, date]`
+- More dimensions = more granular data but potentially more rows
+
+### Search Type Selection
+
+- **web** (default) — Standard web search results
+- **image** — Google Images results
+- **video** — Video search results
+- **news** — Google News results
+- **discover** — Google Discover feed
+- **googleNews** — Google News app/site
+
+### Interpreting Metrics
+
+- **Position** — Average position in search results (1 = top). Lower is better.
+- **CTR** — Click-through rate. Varies significantly by position (position 1 averages ~28%, position 10 averages ~2.5%)
+- **Impressions** — How often your site appeared in results. High impressions + low clicks = opportunity
+- **Clicks** — Actual visits from search results
+
+### High-Opportunity Query Identification
+
+The `get_top_queries` tool automatically flags queries with:
+- Position 4-20 (appearing on page 1-2 but not top 3)
+- Impressions > 100 (meaningful search volume)
+- CTR < 5% (underperforming click-through)
+
+These are the best candidates for SEO optimization — they already rank but could climb higher with improved content, titles, or meta descriptions.
+
+### Site URL Formatting
+
+Search Console properties come in two formats:
+- **URL prefix:** `https://example.com/` (must include trailing slash and protocol)
+- **Domain property:** `sc-domain:example.com` (covers all subdomains and protocols)
+
+Use `google_search_console_list_sites` to get the exact property URL format.
+
+### Report Formatting Preferences
+
+- Use tables for multi-row data with consistent columns
+- Use percentage format for CTR (e.g., 3.45%)
+- Round position to 1 decimal (e.g., 4.2)
+- Use thousands separators for large impression/click counts (e.g., 12,345)
+- Sort by clicks descending for top queries/pages, or by impressions for opportunity analysis
+- Include date range and site URL in report metadata
+- Highlight high-opportunity queries with a distinct marker or separate section
+
+### Error Handling Patterns
+
+When errors occur:
+
+1. **Check authentication** — Run `google_search_console_check_auth_status`; if not authenticated, direct the user to connect their account at https://app.hopkin.ai
+2. **Validate site URL** — Ensure the property URL matches exactly (including protocol and trailing slash)
+3. **Inspect error messages** — Hopkin errors include specific guidance
+4. **Check date range** — Ensure start_date <= end_date, and dates are not in the future
+5. **Consult troubleshooting guide** — See references/troubleshooting.md
+
+---
+
+## Troubleshooting
+
+For detailed troubleshooting guidance, see **references/troubleshooting.md**.
+
+Common quick fixes:
+
+- **"MCP server not found"** — Verify Hopkin MCP configuration and token
+- **"Not authenticated"** — Run `google_search_console_check_auth_status`; direct user to connect their account at https://app.hopkin.ai
+- **"Site not found"** — Verify property URL with `google_search_console_list_sites`; check exact format
+- **"No data available"** — Check date range; recent dates (last 3 days) may be incomplete
+- **"Invalid dimension combination"** — `searchAppearance` cannot be combined with query, page, device, or country
+
+---
+
+## Additional Resources
+
+For more detailed information:
+
+- **references/mcp-tools-reference.md** — Complete Hopkin MCP tool documentation, parameters, and usage examples
+- **references/troubleshooting.md** — Comprehensive error solutions and debugging steps
+- **references/workflows/search-analytics.md** — Detailed search analytics workflow
+- **references/workflows/top-queries.md** — Detailed top queries analysis workflow
+- **references/workflows/performance-comparison.md** — Detailed performance comparison workflow
+- **references/workflows/url-inspection.md** — Detailed URL inspection workflow
+
+---
+
+**Skill Version:** 1.0
+**Last Updated:** 2026-04-17
+**Requires:** Hopkin Google Search Console MCP (https://app.hopkin.ai)

--- a/hopkin/skills/hopkin-google-search-console/references/mcp-tools-reference.md
+++ b/hopkin/skills/hopkin-google-search-console/references/mcp-tools-reference.md
@@ -1,0 +1,211 @@
+# Google Search Console MCP Tools Reference — Hopkin
+
+Complete parameter reference for all Hopkin Google Search Console MCP tools. For setup and authentication, see **SKILL.md**.
+
+---
+
+## Core Tools
+
+### Authentication Tools
+
+#### google_search_console_ping
+Health check. Verify the MCP server is reachable and returns version/timestamp.
+
+**Parameters:**
+- `message` (string, optional, max 100 chars) — Optional message to echo back
+
+#### google_search_console_check_auth_status
+Check whether the user has authenticated their Google Search Console account. Only call this when another tool returns a permission or authentication error — do not call proactively.
+
+**Parameters:** None
+
+**Response includes:**
+- `authenticated` (boolean) — Whether the user is authenticated
+- `user_id` — User identifier
+- `email` — Authenticated email
+- `needs_reconnect` — Present if scope is missing
+
+---
+
+### Site Tools
+
+#### google_search_console_list_sites
+List all Google Search Console properties the user has access to. Results are cached for 15 minutes.
+
+**Parameters:**
+- `refresh` (boolean, optional, default: false) — Force fresh fetch, bypass cache
+
+**Response includes:**
+- Array of properties with `siteUrl` and `permissionLevel` (siteOwner, siteFullUser, siteRestrictedUser, siteUnverifiedUser)
+
+#### google_search_console_list_sitemaps
+List sitemaps submitted to a Google Search Console property.
+
+**Parameters:**
+- `site_url` (string, required) — Search Console property URL (e.g., `https://example.com/` or `sc-domain:example.com`)
+- `refresh` (boolean, optional, default: false) — Force fresh fetch, bypass cache
+
+**Response includes:**
+- List of submitted sitemaps with path, last submission date, pending/error status, and error/warning counts
+
+---
+
+### Analytics Tools
+
+#### google_search_console_get_search_analytics
+Query Google Search Console search analytics data with flexible dimensions. The most versatile analytics tool — use when you need custom dimension combinations, filters, or pagination.
+
+**Parameters:**
+- `site_url` (string, required) — Search Console property URL
+- `start_date` (string, required) — Start date in YYYY-MM-DD format
+- `end_date` (string, required) — End date in YYYY-MM-DD format (must be >= start_date)
+- `dimensions` (array of strings, optional) — Group by dimensions. Valid: `query`, `page`, `device`, `country`, `date`, `searchAppearance`. **Note:** `searchAppearance` cannot be combined with query, page, device, or country — only with `date`
+- `search_type` (string, optional, default: `web`) — Valid: `web`, `image`, `video`, `news`, `discover`, `googleNews`
+- `dimension_filter_groups` (array, optional) — Filter by dimension values
+- `aggregate_by` (string, optional, default: `auto`) — Valid: `auto`, `byPage`, `byProperty`, `byNewsShowcasePanel`
+- `row_limit` (integer, optional, default: 25) — Range: 1-25000
+- `start_row` (integer, optional, default: 0) — Zero-based row offset for pagination
+
+**Response includes:**
+- Array of rows with `{ keys, clicks, impressions, ctr, position }`
+- `rowCount` — Total number of rows
+- `responseAggregationType` — How results were aggregated
+- `firstIncompleteDate` — First date with potentially incomplete data
+
+#### google_search_console_get_top_queries
+Get top queries with clicks, impressions, CTR, and position. Automatically identifies high-opportunity queries (position 4-20, impressions >100, CTR <5%).
+
+**Parameters:**
+- `site_url` (string, required) — Search Console property URL
+- `days` (integer, optional, default: 28) — Range: 1-90
+- `start_date` (string, optional) — Explicit start date (YYYY-MM-DD), overrides `days`
+- `end_date` (string, optional) — Explicit end date (YYYY-MM-DD), overrides `days`
+- `page_filter` (string, optional) — Filter to queries for a specific URL (exact match)
+- `device` (string, optional) — Valid: `desktop`, `mobile`, `tablet`
+- `search_type` (string, optional, default: `web`) — Valid: `web`, `image`, `video`, `news`
+- `row_limit` (integer, optional, default: 25)
+- `start_row` (integer, optional, default: 0)
+
+**Response includes:**
+- `queries` — Array of query rows with clicks, impressions, CTR, position
+- `highOpportunityQueries` — Queries with position 4-20, impressions >100, CTR <5%
+- `site_url` — The queried property
+- `dateRange` — The date range used
+
+#### google_search_console_compare_performance
+Compare current vs previous period performance (period-over-period analysis). Periods are adjacent and non-overlapping.
+
+**Parameters:**
+- `site_url` (string, required) — Search Console property URL
+- `days` (integer, optional, default: 28) — Length of each period in days. Range: 1-90
+- `current_end_date` (string, optional) — End date of current period (YYYY-MM-DD). Default: today minus 3 days
+- `search_type` (string, optional, default: `web`) — Valid: `web`, `image`, `video`, `news`
+
+**Response includes:**
+- `currentPeriod` — Metrics for current period (clicks, impressions, ctr, position)
+- `previousPeriod` — Metrics for previous period
+- `delta` — Change values: clicks, clicksPct, impressions, impressionsPct, ctr, position
+- `trend` — Classification: `improving` (clicks up >10%), `declining` (clicks down >10%), or `stable`
+- `topQueries` — Top queries for current period
+- `previousTopQueries` — Top queries for previous period
+- `errors` — Any partial errors from sub-queries
+
+#### google_search_console_get_performance_overview
+Get complete search performance overview: overall metrics, top queries, top pages, daily trend. Makes 4 parallel API calls internally. Partial results are returned when sub-queries fail.
+
+**Parameters:**
+- `site_url` (string, required) — Search Console property URL
+- `days` (integer, optional, default: 28) — Range: 1-90
+- `search_type` (string, optional, default: `web`) — Valid: `web`, `image`, `video`, `news`
+
+**Response includes:**
+- `overall` — Aggregate metrics: startDate, endDate, clicks, impressions, ctr, position
+- `topQueries` — Top 10 queries by clicks
+- `topPages` — Top 10 pages by clicks
+- `byDate` — Daily breakdown of metrics
+- `dateRange` — The date range used
+- `errors` — Any partial errors from sub-queries
+
+---
+
+### URL Inspection Tools
+
+#### google_search_console_inspect_url
+Get detailed indexing and crawl status for a specific URL. Quota: 2000 calls per day per property.
+
+**Parameters:**
+- `inspection_url` (string, required) — Fully-qualified URL to inspect. Must be under the `site_url` property.
+- `site_url` (string, required) — Search Console property URL containing the inspection URL
+- `language_code` (string, optional) — IETF BCP-47 language code for translated issue messages (e.g., `en-US`)
+
+**Response includes:**
+- `verdict` — PASS, FAIL, or NEUTRAL
+- Coverage state (indexed, excluded, etc.)
+- Robots.txt state
+- Indexing state
+- Page fetch state
+- Last crawl time
+- Crawled as (mobile/desktop)
+- Google canonical URL
+- User canonical URL
+- Sitemap references
+
+---
+
+### Preference Tools
+
+#### google_search_console_store_preference
+Store a persistent preference or observation about a Search Console property.
+
+**Parameters:**
+- `entity_type` (string, required) — Type of entity (e.g., `site`, `query`)
+- `entity_id` (string, required) — Entity identifier (e.g., `https://example.com/`)
+- `key` (string, required, max 100 chars) — Preference key
+- `value` (any, required) — Preference value (string, number, boolean, or JSON object)
+- `source` (string, optional, default: `agent`) — Who set this: `agent`, `user`, `system`
+- `note` (string, optional, max 500 chars) — Context about why preference was set
+
+#### google_search_console_get_preferences
+Retrieve stored preferences for a Search Console entity.
+
+**Parameters:**
+- `entity_type` (string, required) — Type of entity
+- `entity_id` (string, required) — Entity identifier
+
+#### google_search_console_delete_preference
+Delete a stored preference for a Search Console entity.
+
+**Parameters:**
+- `entity_type` (string, required) — Type of entity
+- `entity_id` (string, required) — Entity identifier
+- `key` (string, required) — Preference key to delete
+
+---
+
+### Developer Feedback
+
+#### google_search_console_developer_feedback
+Submit feedback about missing tools, improvements, bugs, or workflow gaps.
+
+**Parameters:**
+- `feedback_type` (string, required) — Category: `new_tool`, `improvement`, `bug`, `workflow_gap`
+- `title` (string, required) — Concise title (5-200 chars)
+- `description` (string, required) — What is needed and why (20-2000 chars)
+- `current_workaround` (string, optional) — Current workaround if any (max 1000 chars)
+- `priority` (string, optional, default: `medium`) — Impact: `low`, `medium`, `high`
+- `interface` (string, optional, default: `MCP`) — Valid: `MCP`, `CLI`
+
+---
+
+## Pagination
+
+Analytics tools support row-based pagination via `start_row` and `row_limit`. Increment `start_row` by `row_limit` to page through results. Continue until returned rows are fewer than `row_limit`.
+
+## Caching
+
+- `list_sites` and `list_sitemaps` results are cached for 15 minutes
+- Use `refresh: true` to bypass cache when fresh data is needed
+
+## Error Handling
+
+See **troubleshooting.md** for detailed error solutions.

--- a/hopkin/skills/hopkin-google-search-console/references/troubleshooting.md
+++ b/hopkin/skills/hopkin-google-search-console/references/troubleshooting.md
@@ -1,0 +1,196 @@
+# Google Search Console Skill - Troubleshooting Guide
+
+This guide provides solutions to common issues encountered when using the Google Search Console skill with the Hopkin Google Search Console MCP.
+
+## Table of Contents
+
+1. [MCP Server Issues](#mcp-server-issues)
+2. [Authentication Problems](#authentication-problems)
+3. [Data Availability Issues](#data-availability-issues)
+4. [Query and Parameter Errors](#query-and-parameter-errors)
+5. [API Error Types](#api-error-types)
+6. [Common Mistakes](#common-mistakes)
+
+---
+
+## MCP Server Issues
+
+### MCP Server Not Found
+
+**Symptoms:**
+- No `google_search_console_` prefixed tools available
+- Cannot execute Search Console operations
+
+**Diagnosis:**
+1. Check for `google_search_console_` prefixed tools in your available tools
+2. If none are found, the Hopkin Google Search Console MCP is not configured
+
+**Solution:** Follow the setup instructions in the Prerequisites section of SKILL.md. If already configured, verify the token is current and restart Claude.
+
+---
+
+## Authentication Problems
+
+### Not Authenticated with Google Search Console
+
+**Symptoms:**
+- `google_search_console_check_auth_status` returns not authenticated
+- Tools return authentication errors
+- Cannot access site data
+
+**Solution:** Direct the user to https://app.hopkin.ai to complete or redo the OAuth flow. If previously connected, the token may have expired.
+
+### Missing Scopes
+
+**Symptoms:**
+- `google_search_console_check_auth_status` returns `needs_reconnect`
+- Some tools work but others fail with permission errors
+
+**Solution:** The user needs to reconnect their Google account at https://app.hopkin.ai to grant the required scopes (`mcp:tools`, `gsc:read`).
+
+### Permission Errors on Specific Sites
+
+**Symptoms:**
+- Can authenticate but cannot access a specific property
+- `list_sites` shows the property with `siteUnverifiedUser` permission level
+
+**Solution:** The user needs to verify ownership or request access to the property in Google Search Console directly. Only `siteOwner`, `siteFullUser`, and `siteRestrictedUser` can query analytics data.
+
+---
+
+## Data Availability Issues
+
+### No Data for Recent Dates
+
+**Symptoms:**
+- Analytics queries for the last 1-2 days return empty or very low numbers
+- `firstIncompleteDate` is set in the response
+
+**Causes & Solutions:**
+
+1. **Normal data lag:** Search Console data has a 2-3 day lag. This is expected behavior. Use dates at least 3 days in the past for reliable data.
+2. **Use the `compare_performance` tool:** It automatically applies a 3-day offset to avoid incomplete data.
+
+### Empty Analytics Results
+
+**Symptoms:**
+- `get_search_analytics` returns zero rows
+- No queries or pages appear
+
+**Causes & Solutions:**
+
+1. **No search traffic:** The site may not have received search traffic in the specified date range.
+2. **Wrong site URL:** Verify the exact property URL (including protocol and trailing slash) with `google_search_console_list_sites`.
+3. **Too narrow filters:** Relax dimension filters or remove them to see if data exists.
+4. **Wrong search type:** Try `search_type: "web"` (default) before filtering by image, video, or news.
+
+### Site Not Found in List
+
+**Symptoms:**
+- `google_search_console_list_sites` does not include the expected property
+
+**Causes & Solutions:**
+
+1. **Wrong Google account:** The user may have the property verified under a different Google account.
+2. **Property not verified:** The property needs to be verified in Google Search Console.
+3. **Cached results:** Try `refresh: true` to bypass the 15-minute cache.
+
+---
+
+## Query and Parameter Errors
+
+### Invalid Dimension Combination
+
+**Symptoms:**
+- Error when using `searchAppearance` with other dimensions
+
+**Solution:** The `searchAppearance` dimension cannot be combined with `query`, `page`, `device`, or `country`. It can only be combined with `date`. Run separate queries for search appearance data.
+
+### Invalid Date Range
+
+**Symptoms:**
+- Error about date validation
+- No results for expected date range
+
+**Causes & Solutions:**
+
+1. **start_date after end_date:** Ensure `start_date` is before or equal to `end_date`.
+2. **Future dates:** Search Console does not have data for future dates.
+3. **Date format:** Use YYYY-MM-DD format (e.g., `2026-04-15`).
+4. **Range too long:** The API limits to 90 days per request for `get_search_analytics`.
+
+### URL Inspection Quota Exceeded
+
+**Symptoms:**
+- `inspect_url` returns a quota error
+
+**Solution:** URL inspection is limited to 2000 calls per day per property. Wait until the next day, or prioritize which URLs to inspect. Consider using `get_search_analytics` with `dimensions: ["page"]` for bulk page-level data instead.
+
+---
+
+## API Error Types
+
+### Rate Limiting
+
+**Symptoms:**
+- 429 status code errors
+- "Too many requests" messages
+
+**Solutions:**
+- Wait briefly and retry
+- Reduce the frequency of tool calls
+- Use caching (avoid `refresh: true` unless necessary)
+
+### Invalid Parameters
+
+**Symptoms:**
+- 400 status code errors
+- "Invalid" or "Bad Request" messages
+
+**Solutions:**
+- Verify all required parameters are provided
+- Check that `site_url` matches exactly (from `list_sites`)
+- Ensure dimension values are from the allowed set
+- Verify date format is YYYY-MM-DD
+
+### Server Errors
+
+**Symptoms:**
+- 500 status code errors
+- Timeout errors
+
+**Solutions:**
+- Retry the request
+- Check MCP server health with `google_search_console_ping`
+- Try a simpler query (fewer dimensions, shorter date range)
+- If persistent, report via `google_search_console_developer_feedback`
+
+---
+
+## Common Mistakes
+
+### Using Wrong Site URL Format
+
+- **URL prefix properties** require exact format: `https://example.com/` (with protocol and trailing slash)
+- **Domain properties** use: `sc-domain:example.com`
+- Always verify with `google_search_console_list_sites` to get the exact format
+
+### Combining searchAppearance with Other Dimensions
+
+The `searchAppearance` dimension is special — it cannot be combined with `query`, `page`, `device`, or `country`. Only combine it with `date`. Run separate queries for other dimension combinations.
+
+### Expecting Real-Time Data
+
+Search Console data is delayed by 2-3 days. Do not expect data from the last 48 hours to be complete. The `compare_performance` tool handles this automatically by offsetting the end date.
+
+### Confusing Position Values
+
+Position 1.0 is the best (top of search results). Higher numbers mean lower rankings. A position change from 8.0 to 4.0 is an **improvement** (moving up in results).
+
+### Calling Auth Check Proactively
+
+`google_search_console_check_auth_status` should only be called when another tool fails with an auth error. Do not call it proactively at the start of every session.
+
+### Not Using Pagination for Large Result Sets
+
+Default `row_limit` is 25. For comprehensive analysis, increase `row_limit` (up to 25,000) or paginate with `start_row`. Top queries analysis may miss important long-tail queries with the default limit.

--- a/hopkin/skills/hopkin-google-search-console/references/workflows/performance-comparison.md
+++ b/hopkin/skills/hopkin-google-search-console/references/workflows/performance-comparison.md
@@ -1,0 +1,117 @@
+# Performance Comparison Report
+
+## When to Use
+
+Use this workflow when you need to:
+
+- Compare search performance between two time periods
+- Identify whether site traffic is improving, stable, or declining
+- Measure the impact of SEO changes, content updates, or algorithm updates
+- Provide period-over-period metrics for stakeholder reporting
+- Detect significant shifts in query rankings or click patterns
+
+## Required Information
+
+- **Site URL** — The Search Console property
+- **Period Length** — Number of days per period (default: 28, range: 1-90)
+- **End Date** — Optional; defaults to today minus 3 days (to account for data lag)
+
+## Detailed Workflow
+
+### Step 1: Run Performance Comparison
+
+Call `google_search_console_compare_performance`:
+
+```json
+{
+  "tool": "google_search_console_compare_performance",
+  "site_url": "https://example.com/",
+  "days": 28,
+  "search_type": "web"
+}
+```
+
+This compares the current 28-day period against the previous 28-day period (non-overlapping, adjacent).
+
+### Step 2: Present Overall Trend
+
+Start with the high-level trend classification and overall metrics:
+
+**Trend: Improving / Stable / Declining**
+
+| Metric | Current Period | Previous Period | Change | Change % |
+|--------|---------------|-----------------|--------|----------|
+| Clicks | ... | ... | +/- ... | +/- ...% |
+| Impressions | ... | ... | +/- ... | +/- ...% |
+| CTR | ...% | ...% | +/- ... pp | — |
+| Avg Position | ... | ... | +/- ... | — |
+
+- Trend is "improving" when clicks are up >10%, "declining" when down >10%, "stable" otherwise
+- Use green/positive indicators for improvements and red/negative for declines
+
+### Step 3: Compare Top Queries
+
+Present side-by-side query comparison:
+
+**Queries gaining traction:**
+- Queries that appear in current top queries but not previous (new rankings)
+- Queries with significant click increases
+
+**Queries losing traction:**
+- Queries that appear in previous top queries but not current
+- Queries with significant click decreases
+
+### Step 4: Analysis and Insights
+
+Provide context for the changes:
+
+- **Traffic growth drivers** — What's contributing to click increases (new content, improved rankings, seasonal trends)
+- **Traffic decline causes** — What might explain decreases (lost rankings, seasonal drops, algorithm changes)
+- **CTR changes** — If CTR changed significantly, it may indicate SERP feature changes or title/description improvements
+- **Position shifts** — Aggregate position changes suggest overall authority trends
+
+### Step 5: Recommendations
+
+Based on the comparison:
+
+- **Improving:** Identify what's working and suggest doubling down on successful strategies
+- **Declining:** Prioritize investigation — check for technical issues, content staleness, or competitive pressure
+- **Stable:** Look for optimization opportunities in high-opportunity queries
+
+## Common Analysis Patterns
+
+### Week-over-Week
+Use `days: 7` for short-term monitoring. Good for detecting immediate impact of changes.
+
+### Month-over-Month
+Use `days: 28` (default) for standard performance reviews. The most common comparison period.
+
+### Quarter-over-Quarter
+Use `days: 90` for strategic reviews. Smooths out weekly fluctuations.
+
+### Custom End Date
+Set `current_end_date` to a specific date to anchor the comparison:
+
+```json
+{
+  "tool": "google_search_console_compare_performance",
+  "site_url": "https://example.com/",
+  "days": 14,
+  "current_end_date": "2026-03-31"
+}
+```
+
+This compares Mar 18-31 vs Mar 4-17.
+
+## Best Practices
+
+- The tool automatically offsets by 3 days to avoid incomplete data — trust this default
+- Position changes of less than 0.5 are generally not significant
+- CTR changes should be interpreted alongside position changes (higher position naturally increases CTR)
+- For algorithm update impact, compare the 14 days before and after the update date using `current_end_date`
+- Always pair with `get_top_queries` for the current period to provide actionable next steps
+
+## See Also
+
+- **top-queries.md** — Detailed query analysis for the current period
+- **search-analytics.md** — Custom dimension queries for deeper investigation

--- a/hopkin/skills/hopkin-google-search-console/references/workflows/search-analytics.md
+++ b/hopkin/skills/hopkin-google-search-console/references/workflows/search-analytics.md
@@ -1,0 +1,136 @@
+# Search Analytics Report
+
+## When to Use
+
+Use this workflow when you need flexible, custom search analytics queries — for example:
+
+- Breaking down performance by specific dimensions (query + page, device + country, etc.)
+- Filtering to specific queries, pages, or devices
+- Analyzing non-web search types (image, video, news, discover)
+- Paginating through large result sets
+- Examining search appearance features (rich results, AMP, etc.)
+
+For simpler "show me top queries" requests, prefer `google_search_console_get_top_queries` instead.
+
+## Required Information
+
+- **Site URL** — The Search Console property (e.g., `https://example.com/` or `sc-domain:example.com`)
+- **Date Range** — Start and end dates in YYYY-MM-DD format
+- **Dimensions** — What to group by (query, page, device, country, date, searchAppearance)
+
+## Detailed Workflow
+
+### Step 1: Verify Site Access
+
+If the site URL is not confirmed, list available properties:
+
+```json
+{
+  "tool": "google_search_console_list_sites"
+}
+```
+
+### Step 2: Query Search Analytics
+
+Call `google_search_console_get_search_analytics` with the appropriate parameters:
+
+```json
+{
+  "tool": "google_search_console_get_search_analytics",
+  "site_url": "https://example.com/",
+  "start_date": "2026-03-15",
+  "end_date": "2026-04-14",
+  "dimensions": ["query", "page"],
+  "search_type": "web",
+  "row_limit": 50
+}
+```
+
+### Step 3: Present Results
+
+Format the data in a sorted table. Choose the sort column based on the user's intent:
+- **Traffic analysis** — Sort by clicks descending
+- **Visibility analysis** — Sort by impressions descending
+- **Ranking analysis** — Sort by position ascending (best first)
+- **Opportunity analysis** — Sort by impressions descending, highlight rows with low CTR
+
+Example table format:
+
+| Query | Page | Clicks | Impressions | CTR | Position |
+|-------|------|--------|-------------|-----|----------|
+| ... | ... | ... | ... | ...% | ... |
+
+### Step 4: Analysis and Insights
+
+Provide actionable insights based on the data:
+
+- **Top performers** — Which queries/pages drive the most traffic
+- **Rising queries** — Queries with high impressions but low clicks (optimization opportunities)
+- **Device differences** — If device dimension is included, note mobile vs desktop variations
+- **Country insights** — If country dimension is included, highlight geographic patterns
+
+### Step 5: Pagination (if needed)
+
+If the user needs more data, paginate:
+
+```json
+{
+  "tool": "google_search_console_get_search_analytics",
+  "site_url": "https://example.com/",
+  "start_date": "2026-03-15",
+  "end_date": "2026-04-14",
+  "dimensions": ["query"],
+  "row_limit": 50,
+  "start_row": 50
+}
+```
+
+## Common Analysis Patterns
+
+### Query + Page Analysis
+Dimensions: `["query", "page"]` — Reveals which pages rank for which queries. Useful for identifying keyword cannibalization (multiple pages ranking for the same query).
+
+### Daily Trend Analysis
+Dimensions: `["date"]` — Shows daily fluctuations. Useful for spotting algorithm updates, seasonal patterns, or the impact of content changes.
+
+### Device Breakdown
+Dimensions: `["device"]` — Compares desktop, mobile, and tablet performance. Important for mobile-first indexing analysis.
+
+### Country Performance
+Dimensions: `["country"]` — Geographic breakdown. Useful for international SEO strategy.
+
+### Search Appearance
+Dimensions: `["searchAppearance"]` or `["searchAppearance", "date"]` — Shows performance of rich results, AMP pages, and other SERP features. **Cannot** be combined with query, page, device, or country.
+
+## Dimension Filter Examples
+
+Filter to a specific page:
+```json
+{
+  "dimension_filter_groups": [{
+    "filters": [{
+      "dimension": "page",
+      "operator": "equals",
+      "expression": "https://example.com/blog/post-1"
+    }]
+  }]
+}
+```
+
+Filter to queries containing a keyword:
+```json
+{
+  "dimension_filter_groups": [{
+    "filters": [{
+      "dimension": "query",
+      "operator": "contains",
+      "expression": "keyword"
+    }]
+  }]
+}
+```
+
+## See Also
+
+- **top-queries.md** — Simplified top queries with automatic opportunity detection
+- **performance-comparison.md** — Period-over-period trend analysis

--- a/hopkin/skills/hopkin-google-search-console/references/workflows/top-queries.md
+++ b/hopkin/skills/hopkin-google-search-console/references/workflows/top-queries.md
@@ -1,0 +1,101 @@
+# Top Queries Report
+
+## When to Use
+
+Use this workflow when you need to:
+
+- Identify the best-performing search queries for a site
+- Find high-opportunity queries that could benefit from SEO optimization
+- Analyze query performance for a specific page
+- Compare query performance across devices
+- Get a quick overview of what people search for to find the site
+
+This is the recommended starting point for most SEO analysis tasks.
+
+## Required Information
+
+- **Site URL** — The Search Console property
+- **Date Range** — Number of days (default: 28) or explicit start/end dates
+
+## Detailed Workflow
+
+### Step 1: Get Top Queries
+
+Call `google_search_console_get_top_queries`:
+
+```json
+{
+  "tool": "google_search_console_get_top_queries",
+  "site_url": "https://example.com/",
+  "days": 28,
+  "row_limit": 50
+}
+```
+
+### Step 2: Present Top Queries
+
+Format the main queries in a table sorted by clicks:
+
+| # | Query | Clicks | Impressions | CTR | Avg Position |
+|---|-------|--------|-------------|-----|--------------|
+| 1 | ... | ... | ... | ...% | ... |
+
+Include totals and date range in the report metadata.
+
+### Step 3: Highlight High-Opportunity Queries
+
+The tool automatically identifies high-opportunity queries (position 4-20, impressions >100, CTR <5%). Present these prominently in a separate section:
+
+**High-Opportunity Queries** — These queries already rank on page 1-2 but have room to improve:
+
+| Query | Position | Impressions | CTR | Why It's an Opportunity |
+|-------|----------|-------------|-----|------------------------|
+| ... | 7.2 | 1,450 | 2.1% | Ranking page 1 but low CTR — improve title/meta description |
+
+### Step 4: Actionable Recommendations
+
+For each high-opportunity query, provide specific recommendations:
+
+- **Position 4-10 (page 1, below fold):** Focus on improving content depth, internal linking, and page experience to move into top 3
+- **Position 11-20 (page 2):** Significant content improvements needed — consider creating dedicated landing pages, improving topical authority
+- **Low CTR with good position:** Title tag and meta description optimization — make them more compelling and relevant
+- **High impressions, low clicks:** The query has volume but the listing isn't enticing — review SERP snippet
+
+### Step 5: Page-Specific Analysis (if relevant)
+
+If the user wants queries for a specific page:
+
+```json
+{
+  "tool": "google_search_console_get_top_queries",
+  "site_url": "https://example.com/",
+  "page_filter": "https://example.com/blog/target-page",
+  "days": 28
+}
+```
+
+This reveals what queries drive traffic to a specific URL and helps optimize that page's content.
+
+## Common Analysis Patterns
+
+### Brand vs Non-Brand Queries
+Separate brand queries (containing the company/product name) from non-brand queries to understand organic discovery vs brand search.
+
+### Device-Specific Analysis
+Run with `device: "mobile"` and `device: "desktop"` separately to identify mobile-specific ranking issues.
+
+### Seasonal Comparison
+Compare `days: 28` results across different months using explicit `start_date`/`end_date` to spot seasonal trends.
+
+## Best Practices
+
+- Start with `row_limit: 50` for a manageable overview, increase if needed
+- Always highlight high-opportunity queries — these are the most actionable insights
+- When presenting to non-technical users, focus on the recommendations rather than raw metrics
+- Pair with `compare_performance` to add trend context
+
+## See Also
+
+- **search-analytics.md** — Custom dimension queries for deeper analysis
+- **performance-comparison.md** — Period-over-period trend analysis
+- **url-inspection.md** — Deep-dive into specific page indexing

--- a/hopkin/skills/hopkin-google-search-console/references/workflows/url-inspection.md
+++ b/hopkin/skills/hopkin-google-search-console/references/workflows/url-inspection.md
@@ -1,0 +1,122 @@
+# URL Inspection Report
+
+## When to Use
+
+Use this workflow when you need to:
+
+- Check whether a specific URL is indexed by Google
+- Diagnose why a page isn't appearing in search results
+- Verify crawl status and last crawl time
+- Check canonical URL resolution (Google's chosen canonical vs user-declared canonical)
+- Verify robots.txt and indexing directives
+- Confirm sitemap coverage for specific URLs
+
+## Required Information
+
+- **Inspection URL** — The fully-qualified URL to inspect (must be under the site property)
+- **Site URL** — The Search Console property that contains the URL
+
+## Detailed Workflow
+
+### Step 1: Inspect the URL
+
+Call `google_search_console_inspect_url`:
+
+```json
+{
+  "tool": "google_search_console_inspect_url",
+  "inspection_url": "https://example.com/blog/my-page",
+  "site_url": "https://example.com/",
+  "language_code": "en-US"
+}
+```
+
+### Step 2: Present Indexing Status
+
+Provide a clear summary of the URL's status:
+
+**URL:** `https://example.com/blog/my-page`
+
+| Aspect | Status | Details |
+|--------|--------|---------|
+| Verdict | PASS / FAIL / NEUTRAL | Overall indexing verdict |
+| Coverage | Submitted and indexed / Excluded / etc. | Current coverage state |
+| Robots.txt | Allowed / Blocked | Whether robots.txt allows crawling |
+| Indexing | Allowed / Blocked (noindex) | Whether indexing directives allow indexing |
+| Page Fetch | Successful / Failed | Whether Google could fetch the page |
+| Crawl Date | YYYY-MM-DD | Last time Google crawled this URL |
+| Crawler | Mobile / Desktop | Which Googlebot variant last crawled |
+
+### Step 3: Canonical Analysis
+
+Compare canonical URLs:
+
+- **User-declared canonical:** What the page's `<link rel="canonical">` or HTTP header specifies
+- **Google-selected canonical:** What Google chose as the canonical version
+
+If these differ, explain the implications:
+- Google may have found a better canonical (e.g., with/without trailing slash, www vs non-www)
+- The page may be considered a duplicate of another URL
+- This can affect which URL appears in search results
+
+### Step 4: Sitemap Coverage
+
+Note whether the URL is referenced in any submitted sitemaps. If not, recommend adding it.
+
+### Step 5: Diagnosis and Recommendations
+
+Based on the inspection results, provide specific guidance:
+
+**If verdict is FAIL:**
+- Check the coverage state for the specific exclusion reason
+- Common exclusions: "Crawled - currently not indexed", "Discovered - currently not indexed", "Excluded by noindex tag", "Blocked by robots.txt"
+- Provide specific fixes for each exclusion type
+
+**If verdict is PASS but page isn't ranking:**
+- The URL is indexed — the issue is ranking, not indexing
+- Redirect to `get_top_queries` with `page_filter` to see what queries the page ranks for
+- Suggest content and on-page SEO improvements
+
+**If verdict is NEUTRAL:**
+- The URL may be an alternate version (e.g., AMP, mobile)
+- Check the canonical URL to find the primary version
+
+## Common Diagnosis Patterns
+
+### Page Not Indexed
+1. Check robots.txt state — is crawling blocked?
+2. Check indexing state — is there a noindex directive?
+3. Check page fetch — can Google access the page?
+4. Check coverage state for the specific reason
+
+### Wrong Canonical Selected
+1. Verify the user-declared canonical is correct
+2. Check for duplicate content across URLs
+3. Ensure internal links consistently point to the preferred URL
+4. Check for redirect chains that might confuse canonicalization
+
+### Page Not Being Crawled
+1. Check last crawl date — it may just be delayed
+2. Verify robots.txt isn't blocking the URL
+3. Check if the page is linked from other crawled pages
+4. Verify the page is in a submitted sitemap
+
+## Quota Considerations
+
+URL inspection is limited to **2000 calls per day per property**. For bulk page analysis:
+- Use `google_search_console_get_search_analytics` with `dimensions: ["page"]` instead
+- Reserve URL inspection for specific pages that need detailed diagnosis
+- Prioritize pages with known issues or high-value content
+
+## Best Practices
+
+- Always present the verdict prominently — it's the most important signal
+- Explain technical terms (robots.txt, canonical, noindex) if the user may not be familiar
+- If the page is not indexed, provide a step-by-step fix plan
+- Cross-reference with sitemap data from `google_search_console_list_sitemaps`
+- For bulk indexing issues, check sitemaps first before inspecting individual URLs
+
+## See Also
+
+- **search-analytics.md** — Page-level performance data (use `dimensions: ["page"]`)
+- **top-queries.md** — Query analysis for a specific page (use `page_filter`)


### PR DESCRIPTION
## Summary
- Adds new `hopkin-google-search-console` skill with full MCP integration (server: `gcs.mcp.hopkin.ai`)
- Covers all 12 GSC MCP tools: search analytics, top queries, performance comparison, URL inspection, site/sitemap listing, preferences, and developer feedback
- Includes 4 workflow references (search-analytics, top-queries, performance-comparison, url-inspection), MCP tools reference, and troubleshooting guide
- Registers MCP server in `.mcp.json` and updates `plugin.json` and `marketplace.json` metadata

## Test plan
- [ ] Verify skill loads correctly in Claude Code with the plugin installed
- [ ] Confirm `google_search_console_` prefixed tools are available when MCP is configured
- [ ] Test prerequisite flow when MCP is not installed (setup instructions display)
- [ ] Validate MCP server URL (`https://gcs.mcp.hopkin.ai/mcp`) is reachable
- [ ] Confirm CI workflow detects the new skill and packages it correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)